### PR TITLE
Code cleanup and other stuff (read notes please)

### DIFF
--- a/BSGO Server/BSGO Server/3dAlgorithm/Algorithm3D.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/Algorithm3D.cs
@@ -59,10 +59,10 @@
 
         public static Vector3 Clamp(Vector3 value, Vector3 min, Vector3 max)
         {
-            Vector3 result = default(Vector3);
-            result.x = Mathf.Clamp(value.x, min.x, max.x);
-            result.y = Mathf.Clamp(value.y, min.y, max.y);
-            result.z = Mathf.Clamp(value.z, min.z, max.z);
+            Vector3 result = default;
+            result.X = Mathf.Clamp(value.X, min.X, max.X);
+            result.Y = Mathf.Clamp(value.Y, min.Y, max.Y);
+            result.Z = Mathf.Clamp(value.Z, min.Z, max.Z);
             return result;
         }
 
@@ -100,14 +100,14 @@
             if (Vector3.Angle(vector, Vector3.Up) < 40f)
             {
                 Vector3 from = vector;
-                from.y = 0f;
+                from.Y = 0f;
                 from.Normalize();
                 vector = Vector3.Slerp(from, Vector3.Up, 5f / 9f);
             }
             else if (Vector3.Angle(vector, Vector3.Down) < 40f)
             {
                 Vector3 from2 = vector;
-                from2.y = 0f;
+                from2.Y = 0f;
                 from2.Normalize();
                 vector = Vector3.Slerp(from2, Vector3.Down, 5f / 9f);
             }
@@ -124,12 +124,12 @@
             return Quaternion.Slerp(q1, q2, rotationAngle / num);
         }
 
+        // AngleAxis needs fix
         public static Quaternion MirrorQuaternion(Quaternion q)
         {
-            float angle = 0f;
             Vector3 axis = Vector3.Zero;
-            q.ToAngleAxis(out angle, out axis);
-            axis.x = 0f - axis.x;
+            q.ToAngleAxis(out float angle, out axis);
+            axis.X = 0f - axis.X;
             return Quaternion.AngleAxis();
         }
 
@@ -230,12 +230,12 @@
 
         public static Vector3 NormalizeEuler(Vector3 v)
         {
-            return new Vector3(NormalizeAngle(v.x), NormalizeAngle(v.y), NormalizeAngle(v.z));
+            return new Vector3(NormalizeAngle(v.X), NormalizeAngle(v.Y), NormalizeAngle(v.Z));
         }
 
         public static Vector3 NormalizeEuler(Vector3 v, Vector3 nearest)
         {
-            return new Vector3(NormalizeAngle(v.x, nearest.x), NormalizeAngle(v.y, nearest.y), NormalizeAngle(v.z, nearest.z));
+            return new Vector3(NormalizeAngle(v.X, nearest.X), NormalizeAngle(v.Y, nearest.Y), NormalizeAngle(v.Z, nearest.Z));
         }
 
         public static float NormalizeAngle(float angle)

--- a/BSGO Server/BSGO Server/3dAlgorithm/Algorithm3D.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/Algorithm3D.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server._3dAlgorithm
+﻿namespace BSGO_Server._3dAlgorithm
 {
     public static class Algorithm3D
     {
@@ -72,12 +68,12 @@ namespace BSGO_Server._3dAlgorithm
 
         public static bool IsNaN(Quaternion q)
         {
-            return float.IsNaN(q.w) || float.IsNaN(q.x) || float.IsNaN(q.y) || float.IsNaN(q.z);
+            return float.IsNaN(q.W) || float.IsNaN(q.X) || float.IsNaN(q.Y) || float.IsNaN(q.Z);
         }
 
         public static bool IsInfinity(Quaternion q)
         {
-            return float.IsInfinity(q.w) || float.IsInfinity(q.x) || float.IsInfinity(q.y) || float.IsInfinity(q.z);
+            return float.IsInfinity(q.W) || float.IsInfinity(q.X) || float.IsInfinity(q.Y) || float.IsInfinity(q.Z);
         }
 
         //public static bool Raycast(GameObject gameObject, Vector3 origin, Vector3 direction, float distance, out RaycastHit raycastHit)
@@ -100,22 +96,22 @@ namespace BSGO_Server._3dAlgorithm
 
         public static Vector3 GetTrueDirection(Vector3 direction)
         {
-            Vector3 vector = direction.normalized;
-            if (Vector3.Angle(vector, Vector3.up) < 40f)
+            Vector3 vector = direction.Normalized;
+            if (Vector3.Angle(vector, Vector3.Up) < 40f)
             {
                 Vector3 from = vector;
                 from.y = 0f;
                 from.Normalize();
-                vector = Vector3.Slerp(from, Vector3.up, 5f / 9f);
+                vector = Vector3.Slerp(from, Vector3.Up, 5f / 9f);
             }
-            else if (Vector3.Angle(vector, Vector3.down) < 40f)
+            else if (Vector3.Angle(vector, Vector3.Down) < 40f)
             {
                 Vector3 from2 = vector;
                 from2.y = 0f;
                 from2.Normalize();
-                vector = Vector3.Slerp(from2, Vector3.down, 5f / 9f);
+                vector = Vector3.Slerp(from2, Vector3.Down, 5f / 9f);
             }
-            return vector.normalized;
+            return vector.Normalized;
         }
 
         public static Quaternion RotateQuaternion(Quaternion q1, Quaternion q2, float rotationAngle)
@@ -131,7 +127,7 @@ namespace BSGO_Server._3dAlgorithm
         public static Quaternion MirrorQuaternion(Quaternion q)
         {
             float angle = 0f;
-            Vector3 axis = Vector3.zero;
+            Vector3 axis = Vector3.Zero;
             q.ToAngleAxis(out angle, out axis);
             axis.x = 0f - axis.x;
             return Quaternion.AngleAxis(0f - angle, axis);
@@ -221,7 +217,7 @@ namespace BSGO_Server._3dAlgorithm
             Vector3 b = s3 - s2;
             Vector3 rhs = a - b;
             Vector3 lhs = s2 - s0;
-            float sqrMagnitude = rhs.sqrMagnitude;
+            float sqrMagnitude = rhs.SqrMagnitude;
             float value = 0f;
             if (!Mathf.Approximately(sqrMagnitude, 0f))
             {

--- a/BSGO Server/BSGO Server/3dAlgorithm/Algorithm3D.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/Algorithm3D.cs
@@ -130,7 +130,7 @@
             Vector3 axis = Vector3.Zero;
             q.ToAngleAxis(out angle, out axis);
             axis.x = 0f - axis.x;
-            return Quaternion.AngleAxis(0f - angle, axis);
+            return Quaternion.AngleAxis();
         }
 
         public static Vector3 Distance(Vector3 s1p0, Vector3 s1p1, Vector3 s2p0, Vector3 s2p1)

--- a/BSGO Server/BSGO Server/3dAlgorithm/Euler3.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/Euler3.cs
@@ -124,7 +124,7 @@ namespace BSGO_Server._3dAlgorithm
         public static Euler3 RotateOverTime(Euler3 start, Euler3 changePerSecond, float dt)
         {
             Vector3 vector = changePerSecond.ComponentsToVector3();
-            Quaternion lhs = Quaternion.AngleAxis(vector.Magnitude * dt, vector.Normalized);
+            Quaternion lhs = Quaternion.AngleAxis();
             return GetRotation(lhs * start.Rotation);
         }
 

--- a/BSGO Server/BSGO Server/3dAlgorithm/Euler3.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/Euler3.cs
@@ -1,69 +1,35 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace BSGO_Server._3dAlgorithm
 {
     public struct Euler3
     {
-        public float pitch;
+        public float Pitch { get; set; }
 
-        public float yaw;
+        public float Yaw { get; set; }
 
-        public float roll;
+        public float Roll { get; set; }
 
-        public static Euler3 zero
+        public static Euler3 Zero => new Euler3(0f, 0f, 0f);
+
+        public static Euler3 Identity => GetRotation(Quaternion.Identity);
+
+        public Quaternion Rotation => Quaternion.Euler(Pitch, Yaw, Roll);
+
+        public Vector3 Direction => Rotation * Vector3.Forward;
+
+        public Euler3(float pitch, float yaw, float roll = 0f)
         {
-            get
-            {
-                return new Euler3(0f, 0f, 0f);
-            }
-        }
-
-        public static Euler3 identity
-        {
-            get
-            {
-                return Rotation(Quaternion.identity);
-            }
-        }
-
-        public Quaternion rotation
-        {
-            get
-            {
-                return Quaternion.Euler(pitch, yaw, roll);
-            }
-        }
-
-        public Vector3 direction
-        {
-            get
-            {
-                return rotation * Vector3.forward;
-            }
-        }
-
-        public Euler3(float pitch, float yaw)
-        {
-            this.pitch = pitch;
-            this.yaw = yaw;
-            roll = 0f;
-        }
-
-        public Euler3(float pitch, float yaw, float roll)
-        {
-            this.pitch = pitch;
-            this.yaw = yaw;
-            this.roll = roll;
+            Pitch = pitch;
+            Yaw = yaw;
+            Roll = roll;
         }
 
         public Euler3 Normalized(bool forceStraight)
         {
-            float num = NormAngle(pitch);
-            float num2 = yaw;
-            float num3 = roll;
-            if (forceStraight && (double)Mathf.Abs(num) > 90.0)
+            float num = NormAngle(Pitch);
+            float num2 = Yaw;
+            float num3 = Roll;
+            if (forceStraight && Mathf.Abs(num) > 90.0)
             {
                 num = NormAngle(179.99f - num);
                 num2 += 179.99f;
@@ -85,156 +51,154 @@ namespace BSGO_Server._3dAlgorithm
             return angle;
         }
 
-        public static Euler3 Direction(Vector3 direction)
+        public static Euler3 GetDirection(Vector3 direction)
         {
             float num = Mathf.Atan2(direction.x, direction.z) * 57.29578f;
             float num2 = (0f - Mathf.Atan2(direction.y, Mathf.Sqrt(direction.x * direction.x + direction.z * direction.z))) * 57.29578f;
             return new Euler3(num2, num, 0f);
         }
 
-        public static Euler3 Rotation(Quaternion quat)
+        public static Euler3 GetRotation(Quaternion quat)
         {
-            float num = quat.x * quat.x;
-            float num2 = quat.y * quat.y;
-            float num3 = quat.z * quat.z;
-            float num4 = quat.w * quat.w;
+            float num = quat.X * quat.X;
+            float num2 = quat.Y * quat.Y;
+            float num3 = quat.Z * quat.Z;
+            float num4 = quat.W * quat.W;
             float num5 = num + num2 + num3 + num4;
-            float num6 = (0f - quat.z) * quat.y + quat.x * quat.w;
+            float num6 = (0f - quat.Z) * quat.Y + quat.X * quat.W;
             float num7;
             float num8;
             float num9;
-            if ((double)num6 > 0.499999 * (double)num5)
+            if (num6 > 0.499999 * num5)
             {
                 num7 = (float)Math.PI / 2f;
-                num8 = 2f * Mathf.Atan2(0f - quat.z, quat.w);
+                num8 = 2f * Mathf.Atan2(0f - quat.Z, quat.W);
                 num9 = 0f;
             }
-            else if ((double)num6 < -0.499999 * (double)num5)
+            else if (num6 < -0.499999 * num5)
             {
                 num7 = -(float)Math.PI / 2f;
-                num8 = -2f * Mathf.Atan2(0f - quat.z, quat.w);
+                num8 = -2f * Mathf.Atan2(0f - quat.Z, quat.W);
                 num9 = 0f;
             }
             else
             {
                 num7 = Mathf.Asin(2f * num6 / num5);
-                num8 = Mathf.Atan2(2f * quat.y * quat.w + 2f * quat.z * quat.x, 0f - num - num2 + num3 + num4);
-                num9 = Mathf.Atan2(2f * quat.z * quat.w + 2f * quat.y * quat.x, 0f - num + num2 - num3 + num4);
+                num8 = Mathf.Atan2(2f * quat.Y * quat.W + 2f * quat.Z * quat.X, 0f - num - num2 + num3 + num4);
+                num9 = Mathf.Atan2(2f * quat.Z * quat.W + 2f * quat.Y * quat.X, 0f - num + num2 - num3 + num4);
             }
             return new Euler3(num7, num8, num9) * 57.29578f;
         }
 
         public void Clamp(Euler3 from, Euler3 to)
         {
-            pitch = Mathf.Clamp(pitch, from.pitch, to.pitch);
-            yaw = Mathf.Clamp(yaw, from.yaw, to.yaw);
-            roll = Mathf.Clamp(roll, from.roll, to.roll);
+            Pitch = Mathf.Clamp(Pitch, from.Pitch, to.Pitch);
+            Yaw = Mathf.Clamp(Yaw, from.Yaw, to.Yaw);
+            Roll = Mathf.Clamp(Roll, from.Roll, to.Roll);
         }
 
         public void ClampMax(Euler3 max)
         {
-            pitch = Mathf.Min(pitch, max.pitch);
-            yaw = Mathf.Min(yaw, max.yaw);
-            roll = Mathf.Min(roll, max.roll);
+            Pitch = Mathf.Min(Pitch, max.Pitch);
+            Yaw = Mathf.Min(Yaw, max.Yaw);
+            Roll = Mathf.Min(Roll, max.Roll);
         }
 
         public void ClampMin(Euler3 min)
         {
-            pitch = Mathf.Max(pitch, min.pitch);
-            yaw = Mathf.Max(yaw, min.yaw);
-            roll = Mathf.Max(roll, min.roll);
+            Pitch = Mathf.Max(Pitch, min.Pitch);
+            Yaw = Mathf.Max(Yaw, min.Yaw);
+            Roll = Mathf.Max(Roll, min.Roll);
         }
 
         public static Euler3 Scale(Euler3 a, Euler3 b)
         {
-            return new Euler3(a.pitch * b.pitch, a.yaw * b.yaw, a.roll * b.roll);
+            return new Euler3(a.Pitch * b.Pitch, a.Yaw * b.Yaw, a.Roll * b.Roll);
         }
 
         public override string ToString()
         {
-            return string.Format("({0},{1},{2})", pitch, yaw, roll);
+            return string.Format("({0},{1},{2})", Pitch, Yaw, Roll);
         }
 
         public static Euler3 RotateOverTime(Euler3 start, Euler3 changePerSecond, float dt)
         {
             Vector3 vector = changePerSecond.ComponentsToVector3();
-            Quaternion lhs = Quaternion.AngleAxis(vector.magnitude * dt, vector.normalized);
-            return Rotation(lhs * start.rotation);
+            Quaternion lhs = Quaternion.AngleAxis(vector.Magnitude * dt, vector.Normalized);
+            return GetRotation(lhs * start.Rotation);
         }
 
         public static Euler3 RotateOverTimeLocal(Euler3 start, Euler3 changePerSecond, float dt)
         {
-            Quaternion rhs = Quaternion.Slerp(Quaternion.identity, changePerSecond.rotation, dt);
-            return Rotation(start.rotation * rhs);
+            Quaternion rhs = Quaternion.Slerp(Quaternion.Identity, changePerSecond.Rotation, dt);
+            return GetRotation(start.Rotation * rhs);
         }
 
         public static Quaternion RotateOverTime(Quaternion start, Quaternion changePerSecond, float dt)
         {
-            Quaternion lhs = Quaternion.Slerp(Quaternion.identity, changePerSecond, dt);
+            Quaternion lhs = Quaternion.Slerp(Quaternion.Identity, changePerSecond, dt);
             return lhs * start;
         }
 
         public static Quaternion RotateOverTimeLocal(Quaternion start, Quaternion changePerSecond, float dt)
         {
-            Quaternion rhs = Quaternion.Slerp(Quaternion.identity, changePerSecond, dt);
+            Quaternion rhs = Quaternion.Slerp(Quaternion.Identity, changePerSecond, dt);
             return start * rhs;
         }
 
         public Vector3 ComponentsToVector3()
         {
-            return new Vector3(pitch, yaw, roll);
+            return new Vector3(Pitch, Yaw, Roll);
         }
 
         public void ComponentsFromVector3(Vector3 input)
         {
-            pitch = input.x;
-            yaw = input.y;
-            roll = input.z;
+            Pitch = input.x;
+            Yaw = input.y;
+            Roll = input.z;
         }
 
-        public override int GetHashCode()
-        {
-            return ((ValueType)this).GetHashCode();
-        }
+        public override int GetHashCode() =>
+            GetHashCode();
+        
 
-        public override bool Equals(object o)
-        {
-            return this == (Euler3)o;
-        }
+        public override bool Equals(object obj) =>
+            this == (Euler3)obj;
+        
 
         public static bool operator ==(Euler3 a, Euler3 b)
         {
-            return a.pitch == b.pitch && a.yaw == b.yaw && a.roll == b.roll;
+            return a.Pitch == b.Pitch && a.Yaw == b.Yaw && a.Roll == b.Roll;
         }
 
         public static bool operator !=(Euler3 a, Euler3 b)
         {
-            return a.pitch != b.pitch || a.yaw != b.yaw || a.roll != b.roll;
+            return a.Pitch != b.Pitch || a.Yaw != b.Yaw || a.Roll != b.Roll;
         }
 
         public static Euler3 operator +(Euler3 a, Euler3 b)
         {
-            return new Euler3(a.pitch + b.pitch, a.yaw + b.yaw, a.roll + b.roll);
+            return new Euler3(a.Pitch + b.Pitch, a.Yaw + b.Yaw, a.Roll + b.Roll);
         }
 
         public static Euler3 operator -(Euler3 a, Euler3 b)
         {
-            return new Euler3(a.pitch - b.pitch, a.yaw - b.yaw, a.roll - b.roll);
+            return new Euler3(a.Pitch - b.Pitch, a.Yaw - b.Yaw, a.Roll - b.Roll);
         }
 
         public static Euler3 operator -(Euler3 a)
         {
-            return new Euler3(0f - a.pitch, 0f - a.yaw, 0f - a.roll);
+            return new Euler3(0f - a.Pitch, 0f - a.Yaw, 0f - a.Roll);
         }
 
         public static Euler3 operator *(Euler3 a, float b)
         {
-            return new Euler3(a.pitch * b, a.yaw * b, a.roll * b);
+            return new Euler3(a.Pitch * b, a.Yaw * b, a.Roll * b);
         }
 
         public static Euler3 operator /(Euler3 a, float b)
         {
-            return new Euler3(a.pitch / b, a.yaw / b, a.roll / b);
+            return new Euler3(a.Pitch / b, a.Yaw / b, a.Roll / b);
         }
     }
 }

--- a/BSGO Server/BSGO Server/3dAlgorithm/Euler3.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/Euler3.cs
@@ -53,8 +53,8 @@ namespace BSGO_Server._3dAlgorithm
 
         public static Euler3 GetDirection(Vector3 direction)
         {
-            float num = Mathf.Atan2(direction.x, direction.z) * 57.29578f;
-            float num2 = (0f - Mathf.Atan2(direction.y, Mathf.Sqrt(direction.x * direction.x + direction.z * direction.z))) * 57.29578f;
+            float num = Mathf.Atan2(direction.X, direction.Z) * 57.29578f;
+            float num2 = (0f - Mathf.Atan2(direction.Y, Mathf.Sqrt(direction.X * direction.X + direction.Z * direction.Z))) * 57.29578f;
             return new Euler3(num2, num, 0f);
         }
 
@@ -153,18 +153,18 @@ namespace BSGO_Server._3dAlgorithm
 
         public void ComponentsFromVector3(Vector3 input)
         {
-            Pitch = input.x;
-            Yaw = input.y;
-            Roll = input.z;
+            Pitch = input.X;
+            Yaw = input.Y;
+            Roll = input.Z;
         }
 
         public override int GetHashCode() =>
             GetHashCode();
-        
+
 
         public override bool Equals(object obj) =>
             this == (Euler3)obj;
-        
+
 
         public static bool operator ==(Euler3 a, Euler3 b)
         {

--- a/BSGO Server/BSGO Server/3dAlgorithm/Mathf.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/Mathf.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace BSGO_Server._3dAlgorithm
 {
@@ -18,109 +16,73 @@ namespace BSGO_Server._3dAlgorithm
         ///   <para>Returns the sine of angle /f/ in radians.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Sin(float f)
-        {
-            return (float)Math.Sin(f);
-        }
+        public static float Sin(float f) => (float)Math.Sin(f);
 
         /// <summary>
         ///   <para>Returns the cosine of angle /f/ in radians.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Cos(float f)
-        {
-            return (float)Math.Cos(f);
-        }
+        public static float Cos(float f) => (float)Math.Cos(f);
 
         /// <summary>
         ///   <para>Returns the tangent of angle /f/ in radians.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Tan(float f)
-        {
-            return (float)Math.Tan(f);
-        }
+        public static float Tan(float f) => (float)Math.Tan(f);
 
         /// <summary>
         ///   <para>Returns the arc-sine of /f/ - the angle in radians whose sine is /f/.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Asin(float f)
-        {
-            return (float)Math.Asin(f);
-        }
+        public static float Asin(float f) => (float)Math.Asin(f);
 
         /// <summary>
         ///   <para>Returns the arc-cosine of /f/ - the angle in radians whose cosine is /f/.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Acos(float f)
-        {
-            return (float)Math.Acos(f);
-        }
+        public static float Acos(float f) => (float)Math.Acos(f);
 
         /// <summary>
         ///   <para>Returns the arc-tangent of /f/ - the angle in radians whose tangent is /f/.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Atan(float f)
-        {
-            return (float)Math.Atan(f);
-        }
+        public static float Atan(float f) => (float)Math.Atan(f);
 
         /// <summary>
         ///   <para>Returns the angle in radians whose ::ref::Tan is @@y/x@@.</para>
         /// </summary>
         /// <param name="y"></param>
         /// <param name="x"></param>
-        public static float Atan2(float y, float x)
-        {
-            return (float)Math.Atan2(y, x);
-        }
+        public static float Atan2(float y, float x) => (float)Math.Atan2(y, x);
 
         /// <summary>
         ///   <para>Returns square root of /f/.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Sqrt(float f)
-        {
-            return (float)Math.Sqrt(f);
-        }
+        public static float Sqrt(float f) => (float)Math.Sqrt(f);
 
         /// <summary>
         ///   <para>Returns the absolute value of /f/.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Abs(float f)
-        {
-            return Math.Abs(f);
-        }
+        public static float Abs(float f) => Math.Abs(f);
 
         /// <summary>
         ///   <para>Returns the absolute value of /value/.</para>
         /// </summary>
         /// <param name="value"></param>
-        public static int Abs(int value)
-        {
-            return Math.Abs(value);
-        }
+        public static int Abs(int value) => Math.Abs(value);
 
         /// <summary>
         ///   <para>Returns the smallest of two or more values.</para>
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
-        /// <param name="values"></param>
-        public static float Min(float a, float b)
-        {
-            return (!(a < b)) ? b : a;
-        }
+        public static float Min(float a, float b) => (!(a < b)) ? b : a;
 
         /// <summary>
         ///   <para>Returns the smallest of two or more values.</para>
         /// </summary>
-        /// <param name="a"></param>
-        /// <param name="b"></param>
         /// <param name="values"></param>
         public static float Min(params float[] values)
         {
@@ -145,17 +107,11 @@ namespace BSGO_Server._3dAlgorithm
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
-        /// <param name="values"></param>
-        public static int Min(int a, int b)
-        {
-            return (a >= b) ? b : a;
-        }
+        public static int Min(int a, int b) => (a >= b) ? b : a;
 
         /// <summary>
         ///   <para>Returns the smallest of two or more values.</para>
         /// </summary>
-        /// <param name="a"></param>
-        /// <param name="b"></param>
         /// <param name="values"></param>
         public static int Min(params int[] values)
         {
@@ -180,17 +136,11 @@ namespace BSGO_Server._3dAlgorithm
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
-        /// <param name="values"></param>
-        public static float Max(float a, float b)
-        {
-            return (!(a > b)) ? b : a;
-        }
+        public static float Max(float a, float b) => (!(a > b)) ? b : a;
 
         /// <summary>
         ///   <para>Returns largest of two or more values.</para>
         /// </summary>
-        /// <param name="a"></param>
-        /// <param name="b"></param>
         /// <param name="values"></param>
         public static float Max(params float[] values)
         {
@@ -215,17 +165,11 @@ namespace BSGO_Server._3dAlgorithm
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
-        /// <param name="values"></param>
-        public static int Max(int a, int b)
-        {
-            return (a <= b) ? b : a;
-        }
+        public static int Max(int a, int b) => (a <= b) ? b : a;
 
         /// <summary>
         ///   <para>Returns the largest of two or more values.</para>
         /// </summary>
-        /// <param name="a"></param>
-        /// <param name="b"></param>
         /// <param name="values"></param>
         public static int Max(params int[] values)
         {
@@ -250,110 +194,74 @@ namespace BSGO_Server._3dAlgorithm
         /// </summary>
         /// <param name="f"></param>
         /// <param name="p"></param>
-        public static float Pow(float f, float p)
-        {
-            return (float)Math.Pow(f, p);
-        }
+        public static float Pow(float f, float p) => (float)Math.Pow(f, p);
 
         /// <summary>
         ///   <para>Returns e raised to the specified power.</para>
         /// </summary>
         /// <param name="power"></param>
-        public static float Exp(float power)
-        {
-            return (float)Math.Exp(power);
-        }
+        public static float Exp(float power) => (float)Math.Exp(power);
 
         /// <summary>
         ///   <para>Returns the logarithm of a specified number in a specified base.</para>
         /// </summary>
         /// <param name="f"></param>
         /// <param name="p"></param>
-        public static float Log(float f, float p)
-        {
-            return (float)Math.Log(f, p);
-        }
+        public static float Log(float f, float p) => (float)Math.Log(f, p);
 
         /// <summary>
         ///   <para>Returns the natural (base e) logarithm of a specified number.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Log(float f)
-        {
-            return (float)Math.Log(f);
-        }
+        public static float Log(float f) => (float)Math.Log(f);
 
         /// <summary>
         ///   <para>Returns the base 10 logarithm of a specified number.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Log10(float f)
-        {
-            return (float)Math.Log10(f);
-        }
+        public static float Log10(float f) => (float)Math.Log10(f);
 
         /// <summary>
         ///   <para>Returns the smallest integer greater to or equal to /f/.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Ceil(float f)
-        {
-            return (float)Math.Ceiling(f);
-        }
+        public static float Ceil(float f) => (float)Math.Ceiling(f);
 
         /// <summary>
         ///   <para>Returns the largest integer smaller to or equal to /f/.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Floor(float f)
-        {
-            return (float)Math.Floor(f);
-        }
+        public static float Floor(float f) => (float)Math.Floor(f);
 
         /// <summary>
         ///   <para>Returns /f/ rounded to the nearest integer.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Round(float f)
-        {
-            return (float)Math.Round(f);
-        }
+        public static float Round(float f) => (float)Math.Round(f);
 
         /// <summary>
         ///   <para>Returns the smallest integer greater to or equal to /f/.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static int CeilToInt(float f)
-        {
-            return (int)Math.Ceiling(f);
-        }
+        public static int CeilToInt(float f) => (int)Math.Ceiling(f);
 
         /// <summary>
         ///   <para>Returns the largest integer smaller to or equal to /f/.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static int FloorToInt(float f)
-        {
-            return (int)Math.Floor(f);
-        }
+        public static int FloorToInt(float f) => (int)Math.Floor(f);
 
         /// <summary>
         ///   <para>Returns /f/ rounded to the nearest integer.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static int RoundToInt(float f)
-        {
-            return (int)Math.Round(f);
-        }
+        public static int RoundToInt(float f) => (int)Math.Round(f);
 
         /// <summary>
         ///   <para>Returns the sign of /f/.</para>
         /// </summary>
         /// <param name="f"></param>
-        public static float Sign(float f)
-        {
-            return (!(f >= 0f)) ? (-1f) : 1f;
-        }
+        public static float Sign(float f) => (!(f >= 0f)) ? (-1f) : 1f;
 
         /// <summary>
         ///   <para>Clamps a value between a minimum float and maximum float value.</para>
@@ -416,10 +324,7 @@ namespace BSGO_Server._3dAlgorithm
         /// <param name="from"></param>
         /// <param name="to"></param>
         /// <param name="t"></param>
-        public static float Lerp(float from, float to, float t)
-        {
-            return from + (to - from) * Clamp01(t);
-        }
+        public static float Lerp(float from, float to, float t) => from + (to - from) * Clamp01(t);
 
         /// <summary>
         ///   <para>Same as ::ref::Lerp but makes sure the values interpolate correctly when they wrap around 360 degrees.</para>
@@ -479,16 +384,11 @@ namespace BSGO_Server._3dAlgorithm
 
         public static float Gamma(float value, float absmax, float gamma)
         {
-            bool flag = false;
-            if (value < 0f)
-            {
-                flag = true;
-            }
+            bool flag = false || value < 0f;
             float num = Abs(value);
             if (num > absmax)
-            {
                 return (!flag) ? num : (0f - num);
-            }
+            
             float num2 = Pow(num / absmax, gamma) * absmax;
             return (!flag) ? num2 : (0f - num2);
         }
@@ -498,20 +398,14 @@ namespace BSGO_Server._3dAlgorithm
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
-        public static bool Approximately(float a, float b)
-        {
-            return Abs(b - a) < Max(1E-06f * Max(Abs(a), Abs(b)), Epsilon * 8f);
-        }
+        public static bool Approximately(float a, float b) => Abs(b - a) < Max(1E-06f * Max(Abs(a), Abs(b)), Epsilon * 8f);
 
         /// <summary>
         ///   <para>Loops the value t, so that it is never larger than length and never smaller than 0.</para>
         /// </summary>
         /// <param name="t"></param>
         /// <param name="length"></param>
-        public static float Repeat(float t, float length)
-        {
-            return t - Floor(t / length) * length;
-        }
+        public static float Repeat(float t, float length) => t - Floor(t / length) * length;
 
         /// <summary>
         ///   <para>Calculates the shortest difference between two given angles given in degrees.</para>
@@ -522,9 +416,8 @@ namespace BSGO_Server._3dAlgorithm
         {
             float num = Repeat(target - current, 360f);
             if (num > 180f)
-            {
                 num -= 360f;
-            }
+            
             return num;
         }
     }

--- a/BSGO Server/BSGO Server/3dAlgorithm/MathfInternal.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/MathfInternal.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server._3dAlgorithm
+﻿namespace BSGO_Server._3dAlgorithm
 {
     public struct MathfInternal
     {

--- a/BSGO Server/BSGO Server/3dAlgorithm/MathfInternal.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/MathfInternal.cs
@@ -6,6 +6,6 @@
 
         public static volatile float FloatMinDenormal = float.Epsilon;
 
-        public static bool IsFlushToZeroEnabled = FloatMinDenormal == 0f;
+        public static bool IsFlushToZeroEnabled = (int)FloatMinDenormal == (int)0f;
     }
 }

--- a/BSGO Server/BSGO Server/3dAlgorithm/Quaternion.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/Quaternion.cs
@@ -13,9 +13,9 @@ namespace BSGO_Server._3dAlgorithm
             get => new Vector3(X, Y, Z);
             set
             {
-                X = value.x;
-                Y = value.y;
-                Z = value.z;
+                X = value.X;
+                Y = value.Y;
+                Z = value.Z;
             }
         }
 
@@ -85,6 +85,7 @@ namespace BSGO_Server._3dAlgorithm
         ///   NEEDS FIX
         ///   <para>Returns the euler angle representation of the rotation.</para>
         /// </summary>
+        /*
         public Vector3 EulerAngles
         {
             get
@@ -98,7 +99,9 @@ namespace BSGO_Server._3dAlgorithm
                 this = new Quaternion(); 
                 //this = Internal_FromEulerRad(value * ((float)Math.PI / 180f));
             }
+            
         }
+        */
 
         /// <summary>
         ///   <para>Constructs new Quaternion with given x,y,z,w components.</para>
@@ -141,8 +144,7 @@ namespace BSGO_Server._3dAlgorithm
         ///   NEEDS FIX
         ///   <para>Creates a rotation which rotates /angle/ degrees around /axis/.</para>
         /// </summary>
-        /// <param name="angle"></param>
-        /// <param name="axis"></param>
+        // args: float angle, Vector3 axis
         public static Quaternion AngleAxis() => new Quaternion();
 
         /// <summary>
@@ -241,9 +243,9 @@ namespace BSGO_Server._3dAlgorithm
 
         private static Quaternion FromEulerRad(Vector3 euler)
         {
-            var yaw = euler.x;
-            var pitch = euler.y;
-            var roll = euler.z;
+            var yaw = euler.X;
+            var pitch = euler.Y;
+            var roll = euler.Z;
             float rollOver2 = roll * 0.5f;
             float sinRollOver2 = (float)Math.Sin(rollOver2);
             float cosRollOver2 = (float)Math.Cos(rollOver2);
@@ -282,9 +284,9 @@ namespace BSGO_Server._3dAlgorithm
             float num11 = rotation.W * num2;
             float num12 = rotation.W * num3;
             Vector3 result = default;
-            result.x = (1f - (num5 + num6)) * point.x + (num7 - num12) * point.y + (num8 + num11) * point.z;
-            result.y = (num7 + num12) * point.x + (1f - (num4 + num6)) * point.y + (num9 - num10) * point.z;
-            result.z = (num8 - num11) * point.x + (num9 + num10) * point.y + (1f - (num4 + num5)) * point.z;
+            result.X = (1f - (num5 + num6)) * point.X + (num7 - num12) * point.Y + (num8 + num11) * point.Z;
+            result.Y = (num7 + num12) * point.X + (1f - (num4 + num6)) * point.Y + (num9 - num10) * point.Z;
+            result.Z = (num8 - num11) * point.X + (num9 + num10) * point.Y + (1f - (num4 + num5)) * point.Z;
             return result;
         }
 

--- a/BSGO Server/BSGO Server/3dAlgorithm/Quaternion.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/Quaternion.cs
@@ -226,18 +226,16 @@ namespace BSGO_Server._3dAlgorithm
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <param name="z"></param>
-        public static Quaternion Euler(float x, float y, float z)
-        {
-            return FromEulerRad(new Vector3(x, y, z) * degToRad);
-        }
+        public static Quaternion Euler(float x, float y, float z) =>
+            FromEulerRad(new Vector3(x, y, z) * degToRad);
+        
         /// <summary>
         ///   <para>Returns a rotation that rotates z degrees around the z axis, x degrees around the x axis, and y degrees around the y axis (in that order).</para>
         /// </summary>
         /// <param name="euler"></param>
-        public static Quaternion Euler(Vector3 euler)
-        {
-            return FromEulerRad(euler * degToRad);
-        }
+        public static Quaternion Euler(Vector3 euler) => 
+            FromEulerRad(euler * degToRad);
+        
 
         private static Quaternion FromEulerRad(Vector3 euler)
         {

--- a/BSGO Server/BSGO Server/3dAlgorithm/Quaternion.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/Quaternion.cs
@@ -5,8 +5,8 @@ namespace BSGO_Server._3dAlgorithm
     public struct Quaternion
     {
         public const float kEpsilon = 1E-06f;
-        const float radToDeg = (float)(180.0 / Math.PI);
-        const float degToRad = (float)(Math.PI / 180.0);
+        private const float radToDeg = (float)(180.0 / Math.PI);
+        private const float degToRad = (float)(Math.PI / 180.0);
 
         public Vector3 Xyz
         {
@@ -82,6 +82,7 @@ namespace BSGO_Server._3dAlgorithm
         public static Quaternion Identity => new Quaternion(0f, 0f, 0f, 1f);
 
         /// <summary>
+        ///   NEEDS FIX
         ///   <para>Returns the euler angle representation of the rotation.</para>
         /// </summary>
         public Vector3 EulerAngles
@@ -94,7 +95,7 @@ namespace BSGO_Server._3dAlgorithm
             // no value param being used
             set
             {
-                this = new Quaternion();
+                this = new Quaternion(); 
                 //this = Internal_FromEulerRad(value * ((float)Math.PI / 180f));
             }
         }
@@ -137,6 +138,7 @@ namespace BSGO_Server._3dAlgorithm
         public static float Dot(Quaternion a, Quaternion b) => a.X * b.X + a.Y * b.Y + a.Z * b.Z + a.W * b.W;
 
         /// <summary>
+        ///   NEEDS FIX
         ///   <para>Creates a rotation which rotates /angle/ degrees around /axis/.</para>
         /// </summary>
         /// <param name="angle"></param>

--- a/BSGO Server/BSGO Server/3dAlgorithm/Quaternion.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/Quaternion.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace BSGO_Server._3dAlgorithm
 {
@@ -10,73 +8,62 @@ namespace BSGO_Server._3dAlgorithm
         const float radToDeg = (float)(180.0 / Math.PI);
         const float degToRad = (float)(Math.PI / 180.0);
 
-        public Vector3 xyz
+        public Vector3 Xyz
         {
+            get => new Vector3(X, Y, Z);
             set
             {
-                x = value.x;
-                y = value.y;
-                z = value.z;
-            }
-            get
-            {
-                return new Vector3(x, y, z);
+                X = value.x;
+                Y = value.y;
+                Z = value.z;
             }
         }
 
         /// <summary>
         ///   <para>X component of the Quaternion. Don't modify this directly unless you know quaternions inside out.</para>
         /// </summary>
-        public float x;
+        public float X { get; set; }
 
         /// <summary>
         ///   <para>Y component of the Quaternion. Don't modify this directly unless you know quaternions inside out.</para>
         /// </summary>
-        public float y;
+        public float Y { get; set; }
 
         /// <summary>
         ///   <para>Z component of the Quaternion. Don't modify this directly unless you know quaternions inside out.</para>
         /// </summary>
-        public float z;
+        public float Z { get; set; }
 
         /// <summary>
         ///   <para>W component of the Quaternion. Don't modify this directly unless you know quaternions inside out.</para>
         /// </summary>
-        public float w;
+        public float W { get; set; }
 
         public float this[int index]
         {
-            get
+            get => index switch
             {
-                switch (index)
-                {
-                    case 0:
-                        return x;
-                    case 1:
-                        return y;
-                    case 2:
-                        return z;
-                    case 3:
-                        return w;
-                    default:
-                        throw new IndexOutOfRangeException("Invalid Quaternion index!");
-                }
-            }
+                0 => X,
+                1 => Y,
+                2 => Z,
+                3 => W,
+                _ => throw new IndexOutOfRangeException("Invalid Quaternion index!"),
+            };
             set
             {
                 switch (index)
                 {
                     case 0:
-                        x = value;
+                        X = value;
                         break;
                     case 1:
-                        y = value;
+                        Y = value;
                         break;
                     case 2:
-                        z = value;
+                        Z = value;
                         break;
                     case 3:
-                        w = value;
+                        W = value;
                         break;
                     default:
                         throw new IndexOutOfRangeException("Invalid Quaternion index!");
@@ -87,36 +74,24 @@ namespace BSGO_Server._3dAlgorithm
         /// <summary>
         /// Gets the length (magnitude) of the quaternion.
         /// </summary>
-        /// <seealso cref="LengthSquared"/>
-        public float Length
-        {
-            get
-            {
-                return (float)Math.Sqrt(x * x + y * y + z * z + w * w);
-            }
-        }
+        public float Length => (float)Math.Sqrt(X * X + Y * Y + Z * Z + W * W);
 
         /// <summary>
         ///   <para>The identity rotation (RO).</para>
         /// </summary>
-        public static Quaternion identity
-        {
-            get
-            {
-                return new Quaternion(0f, 0f, 0f, 1f);
-            }
-        }
+        public static Quaternion Identity => new Quaternion(0f, 0f, 0f, 1f);
 
         /// <summary>
         ///   <para>Returns the euler angle representation of the rotation.</para>
         /// </summary>
-        public Vector3 eulerAngles
+        public Vector3 EulerAngles
         {
             get
             {
                 return new Vector3();
                 //return Internal_ToEulerRad(this) * 57.29578f;
             }
+            // no value param being used
             set
             {
                 this = new Quaternion();
@@ -133,10 +108,10 @@ namespace BSGO_Server._3dAlgorithm
         /// <param name="w"></param>
         public Quaternion(float x, float y, float z, float w)
         {
-            this.x = x;
-            this.y = y;
-            this.z = z;
-            this.w = w;
+            X = x;
+            Y = y;
+            Z = z;
+            W = w;
         }
 
         /// <summary>
@@ -148,10 +123,10 @@ namespace BSGO_Server._3dAlgorithm
         /// <param name="new_w"></param>
         public void Set(float new_x, float new_y, float new_z, float new_w)
         {
-            x = new_x;
-            y = new_y;
-            z = new_z;
-            w = new_w;
+            X = new_x;
+            Y = new_y;
+            Z = new_z;
+            W = new_w;
         }
 
         /// <summary>
@@ -159,20 +134,14 @@ namespace BSGO_Server._3dAlgorithm
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
-        public static float Dot(Quaternion a, Quaternion b)
-        {
-            return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
-        }
+        public static float Dot(Quaternion a, Quaternion b) => a.X * b.X + a.Y * b.Y + a.Z * b.Z + a.W * b.W;
 
         /// <summary>
         ///   <para>Creates a rotation which rotates /angle/ degrees around /axis/.</para>
         /// </summary>
         /// <param name="angle"></param>
         /// <param name="axis"></param>
-        public static Quaternion AngleAxis(float angle, Vector3 axis)
-        {
-            return new Quaternion();
-        }
+        public static Quaternion AngleAxis() => new Quaternion();
 
         /// <summary>
         ///   <para>Returns the angle in degrees between two rotations /a/ and /b/.</para>
@@ -189,9 +158,9 @@ namespace BSGO_Server._3dAlgorithm
         {
             float num2;
             float num3;
-            Quaternion quaternion;
+            Quaternion quaternion = new Quaternion();
             float num = t;
-            float num4 = (((q1.x * q2.x) + (q1.y * q2.y)) + (q1.z * q2.z)) + (q1.w * q2.w);
+            float num4 = (((q1.X * q2.X) + (q1.Y * q2.Y)) + (q1.Z * q2.Z)) + (q1.W * q2.W);
             bool flag = false;
             if (num4 < 0f)
             {
@@ -210,28 +179,28 @@ namespace BSGO_Server._3dAlgorithm
                 num3 = (MathF.Sin(((1f - num) * num5))) * num6;
                 num2 = flag ? ((-MathF.Sin((num * num5))) * num6) : ((MathF.Sin((num * num5))) * num6);
             }
-            quaternion.x = (num3 * q1.x) + (num2 * q2.x);
-            quaternion.y = (num3 * q1.y) + (num2 * q2.y);
-            quaternion.z = (num3 * q1.z) + (num2 * q2.z);
-            quaternion.w = (num3 * q1.w) + (num2 * q2.w);
+            quaternion.X = (num3 * q1.X) + (num2 * q2.X);
+            quaternion.Y = (num3 * q1.Y) + (num2 * q2.Y);
+            quaternion.Z = (num3 * q1.Z) + (num2 * q2.Z);
+            quaternion.W = (num3 * q1.W) + (num2 * q2.W);
             return quaternion;
         }
 
         public void ToAngleAxis(out float angle, out Vector3 axis)
         {
-            Quaternion.ToAxisAngleRad(this, out axis, out angle);
+            ToAxisAngleRad(this, out axis, out angle);
             angle *= radToDeg;
         }
 
         private static void ToAxisAngleRad(Quaternion q, out Vector3 axis, out float angle)
         {
-            if (Math.Abs(q.w) > 1.0f)
+            if (Math.Abs(q.W) > 1.0f)
                 q.Normalize();
-            angle = 2.0f * (float)Math.Acos(q.w); // angle
-            float den = (float)Math.Sqrt(1.0 - q.w * q.w);
+            angle = 2.0f * (float)Math.Acos(q.W); // angle
+            float den = (float)Math.Sqrt(1.0 - q.W * q.W);
             if (den > 0.0001f)
             {
-                axis = q.xyz / den;
+                axis = q.Xyz / den;
             }
             else
             {
@@ -246,9 +215,9 @@ namespace BSGO_Server._3dAlgorithm
         /// </summary>
         public void Normalize()
         {
-            float scale = 1.0f / this.Length;
-            xyz *= scale;
-            w *= scale;
+            float scale = 1.0f / Length;
+            Xyz *= scale;
+            W *= scale;
         }
 
         /// <summary>
@@ -259,7 +228,7 @@ namespace BSGO_Server._3dAlgorithm
         /// <param name="z"></param>
         public static Quaternion Euler(float x, float y, float z)
         {
-            return FromEulerRad(new Vector3((float)x, (float)y, (float)z) * degToRad);
+            return FromEulerRad(new Vector3(x, y, z) * degToRad);
         }
         /// <summary>
         ///   <para>Returns a rotation that rotates z degrees around the z axis, x degrees around the x axis, and y degrees around the y axis (in that order).</para>
@@ -276,66 +245,56 @@ namespace BSGO_Server._3dAlgorithm
             var pitch = euler.y;
             var roll = euler.z;
             float rollOver2 = roll * 0.5f;
-            float sinRollOver2 = (float)System.Math.Sin((float)rollOver2);
-            float cosRollOver2 = (float)System.Math.Cos((float)rollOver2);
+            float sinRollOver2 = (float)Math.Sin(rollOver2);
+            float cosRollOver2 = (float)Math.Cos(rollOver2);
             float pitchOver2 = pitch * 0.5f;
-            float sinPitchOver2 = (float)System.Math.Sin((float)pitchOver2);
-            float cosPitchOver2 = (float)System.Math.Cos((float)pitchOver2);
+            float sinPitchOver2 = (float)Math.Sin(pitchOver2);
+            float cosPitchOver2 = (float)Math.Cos(pitchOver2);
             float yawOver2 = yaw * 0.5f;
-            float sinYawOver2 = (float)System.Math.Sin((float)yawOver2);
-            float cosYawOver2 = (float)System.Math.Cos((float)yawOver2);
-            Quaternion result;
-            result.x = cosYawOver2 * cosPitchOver2 * cosRollOver2 + sinYawOver2 * sinPitchOver2 * sinRollOver2;
-            result.y = cosYawOver2 * cosPitchOver2 * sinRollOver2 - sinYawOver2 * sinPitchOver2 * cosRollOver2;
-            result.z = cosYawOver2 * sinPitchOver2 * cosRollOver2 + sinYawOver2 * cosPitchOver2 * sinRollOver2;
-            result.w = sinYawOver2 * cosPitchOver2 * cosRollOver2 - cosYawOver2 * sinPitchOver2 * sinRollOver2;
+            float sinYawOver2 = (float)Math.Sin(yawOver2);
+            float cosYawOver2 = (float)Math.Cos(yawOver2);
+            Quaternion result = new Quaternion
+            {
+                X = cosYawOver2 * cosPitchOver2 * cosRollOver2 + sinYawOver2 * sinPitchOver2 * sinRollOver2,
+                Y = cosYawOver2 * cosPitchOver2 * sinRollOver2 - sinYawOver2 * sinPitchOver2 * cosRollOver2,
+                Z = cosYawOver2 * sinPitchOver2 * cosRollOver2 + sinYawOver2 * cosPitchOver2 * sinRollOver2,
+                W = sinYawOver2 * cosPitchOver2 * cosRollOver2 - cosYawOver2 * sinPitchOver2 * sinRollOver2
+            };
             return result;
 
         }
 
-        public static Quaternion operator *(Quaternion lhs, Quaternion rhs)
-        {
-            return new Quaternion(lhs.w * rhs.x + lhs.x * rhs.w + lhs.y * rhs.z - lhs.z * rhs.y, lhs.w * rhs.y + lhs.y * rhs.w + lhs.z * rhs.x - lhs.x * rhs.z, lhs.w * rhs.z + lhs.z * rhs.w + lhs.x * rhs.y - lhs.y * rhs.x, lhs.w * rhs.w - lhs.x * rhs.x - lhs.y * rhs.y - lhs.z * rhs.z);
-        }
+        public static Quaternion operator *(Quaternion lhs, Quaternion rhs) =>
+            new Quaternion(lhs.W * rhs.X + lhs.X * rhs.W + lhs.Y * rhs.Z - lhs.Z * rhs.Y, lhs.W * rhs.Y + lhs.Y * rhs.W + lhs.Z * rhs.X - lhs.X * rhs.Z, lhs.W * rhs.Z + lhs.Z * rhs.W + lhs.X * rhs.Y - lhs.Y * rhs.X, lhs.W * rhs.W - lhs.X * rhs.X - lhs.Y * rhs.Y - lhs.Z * rhs.Z);
 
         public static Vector3 operator *(Quaternion rotation, Vector3 point)
         {
-            float num = rotation.x * 2f;
-            float num2 = rotation.y * 2f;
-            float num3 = rotation.z * 2f;
-            float num4 = rotation.x * num;
-            float num5 = rotation.y * num2;
-            float num6 = rotation.z * num3;
-            float num7 = rotation.x * num2;
-            float num8 = rotation.x * num3;
-            float num9 = rotation.y * num3;
-            float num10 = rotation.w * num;
-            float num11 = rotation.w * num2;
-            float num12 = rotation.w * num3;
-            Vector3 result = default(Vector3);
+            float num = rotation.X * 2f;
+            float num2 = rotation.Y * 2f;
+            float num3 = rotation.Z * 2f;
+            float num4 = rotation.X * num;
+            float num5 = rotation.Y * num2;
+            float num6 = rotation.Z * num3;
+            float num7 = rotation.X * num2;
+            float num8 = rotation.X * num3;
+            float num9 = rotation.Y * num3;
+            float num10 = rotation.W * num;
+            float num11 = rotation.W * num2;
+            float num12 = rotation.W * num3;
+            Vector3 result = default;
             result.x = (1f - (num5 + num6)) * point.x + (num7 - num12) * point.y + (num8 + num11) * point.z;
             result.y = (num7 + num12) * point.x + (1f - (num4 + num6)) * point.y + (num9 - num10) * point.z;
             result.z = (num8 - num11) * point.x + (num9 + num10) * point.y + (1f - (num4 + num5)) * point.z;
             return result;
         }
 
-        public static bool operator ==(Quaternion lhs, Quaternion rhs)
-        {
-            return Dot(lhs, rhs) > 0.999999f;
-        }
+        public static bool operator ==(Quaternion lhs, Quaternion rhs) => Dot(lhs, rhs) > 0.999999f;
 
-        public static bool operator !=(Quaternion lhs, Quaternion rhs)
-        {
-            return Dot(lhs, rhs) <= 0.999999f;
-        }
+        public static bool operator !=(Quaternion lhs, Quaternion rhs) => Dot(lhs, rhs) <= 0.999999f;
 
         /// <summary>
         ///   <para>Returns a nicely formatted string of the Quaternion.</para>
         /// </summary>
-        /// <param name="format"></param>
-        public override string ToString()
-        {
-            return string.Format("({0:F1}, {1:F1}, {2:F1}, {3:F1})", x, y, z, w);
-        }
+        public override string ToString() => string.Format("({0:F1}, {1:F1}, {2:F1}, {3:F1})", X, Y, Z, W);
     }
 }

--- a/BSGO Server/BSGO Server/3dAlgorithm/Vector3.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/Vector3.cs
@@ -9,25 +9,25 @@ namespace BSGO_Server._3dAlgorithm
         /// <summary>
         ///   <para>X component of the vector.</para>
         /// </summary>
-        public float x;
+        public float X { get; set; }
 
         /// <summary>
         ///   <para>Y component of the vector.</para>
         /// </summary>
-        public float y;
+        public float Y { get; set; }
 
         /// <summary>
         ///   <para>Z component of the vector.</para>
         /// </summary>
-        public float z;
+        public float Z { get; set; }
 
         public float this[int index]
         {
             get => index switch
             {
-                0 => x,
-                1 => y,
-                2 => z,
+                0 => X,
+                1 => Y,
+                2 => Z,
                 _ => throw new IndexOutOfRangeException("Invalid Vector3 index!"),
             };
             set
@@ -35,13 +35,13 @@ namespace BSGO_Server._3dAlgorithm
                 switch (index)
                 {
                     case 0:
-                        x = value;
+                        X = value;
                         break;
                     case 1:
-                        y = value;
+                        Y = value;
                         break;
                     case 2:
-                        z = value;
+                        Z = value;
                         break;
                     default:
                         throw new IndexOutOfRangeException("Invalid Vector3 index!");
@@ -57,12 +57,12 @@ namespace BSGO_Server._3dAlgorithm
         /// <summary>
         ///   <para>Returns the length of this vector (RO).</para>
         /// </summary>
-        public float Magnitude => MathF.Sqrt(x * x + y * y + z * z);
+        public float Magnitude => MathF.Sqrt(X * X + Y * Y + Z * Z);
 
         /// <summary>
         ///   <para>Returns the squared length of this vector (RO).</para>
         /// </summary>
-        public float SqrMagnitude => x * x + y * y + z * z;
+        public float SqrMagnitude => X * X + Y * Y + Z * Z;
 
         /// <summary>
         ///   <para>Shorthand for writing @@Vector3(0, 0, 0)@@.</para>
@@ -105,28 +105,16 @@ namespace BSGO_Server._3dAlgorithm
         public static Vector3 Right => new Vector3(1f, 0f, 0f);
 
         /// <summary>
-        ///   <para>Creates a new vector with given x, y, z components.</para>
+        ///   <para>Creates a new vector with given x, y, z components. (Z default is 0)</para>
         /// </summary>
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <param name="z"></param>
-        public Vector3(float x, float y, float z)
+        public Vector3(float x, float y, float z = 0)
         {
-            this.x = x;
-            this.y = y;
-            this.z = z;
-        }
-
-        /// <summary>
-        ///   <para>Creates a new vector with given x, y components and sets /z/ to zero.</para>
-        /// </summary>
-        /// <param name="x"></param>
-        /// <param name="y"></param>
-        public Vector3(float x, float y)
-        {
-            this.x = x;
-            this.y = y;
-            z = 0f;
+            X = x;
+            Y = y;
+            Z = z;
         }
 
         /// <summary>
@@ -138,7 +126,7 @@ namespace BSGO_Server._3dAlgorithm
         public static Vector3 Lerp(Vector3 from, Vector3 to, float t)
         {
             t = Math.Clamp(t, 0, 1);
-            return new Vector3(from.x + (to.x - from.x) * t, from.y + (to.y - from.y) * t, from.z + (to.z - from.z) * t);
+            return new Vector3(from.X + (to.X - from.X) * t, from.Y + (to.Y - from.Y) * t, from.Z + (to.Z - from.Z) * t);
         }
 
         /// <summary>
@@ -154,7 +142,7 @@ namespace BSGO_Server._3dAlgorithm
             float theta = MathF.Acos(dot) * t;
             Vector3 RelativeVec = to - from * dot;
             RelativeVec.Normalize();
-            return ((from * MathF.Cos(theta)) + (RelativeVec * MathF.Sin(theta)));
+            return (from * MathF.Cos(theta)) + (RelativeVec * MathF.Sin(theta));
         }
 
         /// <summary>
@@ -194,7 +182,7 @@ namespace BSGO_Server._3dAlgorithm
         /// <param name="rhs"></param>
         public static float Dot(Vector3 lhs, Vector3 rhs)
         {
-            return lhs.x * rhs.x + lhs.y * rhs.y + lhs.z * rhs.z;
+            return lhs.X * rhs.X + lhs.Y * rhs.Y + lhs.Z * rhs.Z;
         }
 
         /// <summary>
@@ -204,21 +192,21 @@ namespace BSGO_Server._3dAlgorithm
         /// <param name="to">The angle extends round to this vector.</param>
         public static float Angle(Vector3 from, Vector3 to) => MathF.Acos(Math.Clamp(Dot(from.Normalized, to.Normalized), -1f, 1f)) * 57.29578f;
 
-        public static float GetMagnitude(Vector3 a) => MathF.Sqrt(a.x * a.x + a.y * a.y + a.z * a.z);
+        public static float GetMagnitude(Vector3 a) => MathF.Sqrt(a.X * a.X + a.Y * a.Y + a.Z * a.Z);
 
-        public static float GetSqrMagnitude(Vector3 a) => a.x * a.x + a.y * a.y + a.z * a.z;
+        public static float GetSqrMagnitude(Vector3 a) => a.X * a.X + a.Y * a.Y + a.Z * a.Z;
 
-        public static Vector3 operator +(Vector3 a, Vector3 b) => new Vector3(a.x + b.x, a.y + b.y, a.z + b.z);
+        public static Vector3 operator +(Vector3 a, Vector3 b) => new Vector3(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
 
-        public static Vector3 operator -(Vector3 a, Vector3 b) => new Vector3(a.x - b.x, a.y - b.y, a.z - b.z);
+        public static Vector3 operator -(Vector3 a, Vector3 b) => new Vector3(a.X - b.X, a.Y - b.Y, a.Z - b.Z);
 
-        public static Vector3 operator -(Vector3 a) => new Vector3(0f - a.x, 0f - a.y, 0f - a.z);
+        public static Vector3 operator -(Vector3 a) => new Vector3(0f - a.X, 0f - a.Y, 0f - a.Z);
 
-        public static Vector3 operator *(Vector3 a, float d) => new Vector3(a.x * d, a.y * d, a.z * d);
+        public static Vector3 operator *(Vector3 a, float d) => new Vector3(a.X * d, a.Y * d, a.Z * d);
 
-        public static Vector3 operator *(float d, Vector3 a) => new Vector3(a.x * d, a.y * d, a.z * d);
+        public static Vector3 operator *(float d, Vector3 a) => new Vector3(a.X * d, a.Y * d, a.Z * d);
 
-        public static Vector3 operator /(Vector3 a, float d) => new Vector3(a.x / d, a.y / d, a.z / d);
+        public static Vector3 operator /(Vector3 a, float d) => new Vector3(a.X / d, a.Y / d, a.Z / d);
 
         public static bool operator ==(Vector3 lhs, Vector3 rhs) => GetSqrMagnitude(lhs - rhs) < 9.99999944E-11f;
 
@@ -227,6 +215,6 @@ namespace BSGO_Server._3dAlgorithm
         /// <summary>
         ///   <para>Returns a nicely formatted string for this vector.</para>
         /// </summary>
-        public override string ToString() => string.Format("({0:F1}, {1:F1}, {2:F1})", x, y, z);
+        public override string ToString() => string.Format("({0:F1}, {1:F1}, {2:F1})", X, Y, Z);
     }
 }

--- a/BSGO Server/BSGO Server/3dAlgorithm/Vector3.cs
+++ b/BSGO Server/BSGO Server/3dAlgorithm/Vector3.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace BSGO_Server._3dAlgorithm
 {
@@ -25,20 +23,13 @@ namespace BSGO_Server._3dAlgorithm
 
         public float this[int index]
         {
-            get
+            get => index switch
             {
-                switch (index)
-                {
-                    case 0:
-                        return x;
-                    case 1:
-                        return y;
-                    case 2:
-                        return z;
-                    default:
-                        throw new IndexOutOfRangeException("Invalid Vector3 index!");
-                }
-            }
+                0 => x,
+                1 => y,
+                2 => z,
+                _ => throw new IndexOutOfRangeException("Invalid Vector3 index!"),
+            };
             set
             {
                 switch (index)
@@ -61,123 +52,57 @@ namespace BSGO_Server._3dAlgorithm
         /// <summary>
         ///   <para>Returns this vector with a ::ref::magnitude of 1 (RO).</para>
         /// </summary>
-        public Vector3 normalized
-        {
-            get
-            {
-                return Normalize(this);
-            }
-        }
+        public Vector3 Normalized => Normalize(this);
 
         /// <summary>
         ///   <para>Returns the length of this vector (RO).</para>
         /// </summary>
-        public float magnitude
-        {
-            get
-            {
-                return MathF.Sqrt(x * x + y * y + z * z);
-            }
-        }
+        public float Magnitude => MathF.Sqrt(x * x + y * y + z * z);
 
         /// <summary>
         ///   <para>Returns the squared length of this vector (RO).</para>
         /// </summary>
-        public float sqrMagnitude
-        {
-            get
-            {
-                return x * x + y * y + z * z;
-            }
-        }
+        public float SqrMagnitude => x * x + y * y + z * z;
 
         /// <summary>
         ///   <para>Shorthand for writing @@Vector3(0, 0, 0)@@.</para>
         /// </summary>
-        public static Vector3 zero
-        {
-            get
-            {
-                return new Vector3(0f, 0f, 0f);
-            }
-        }
+        public static Vector3 Zero => new Vector3(0f, 0f, 0f);
 
         /// <summary>
         ///   <para>Shorthand for writing @@Vector3(1, 1, 1)@@.</para>
         /// </summary>
-        public static Vector3 one
-        {
-            get
-            {
-                return new Vector3(1f, 1f, 1f);
-            }
-        }
+        public static Vector3 One => new Vector3(1f, 1f, 1f);
 
         /// <summary>
         ///   <para>Shorthand for writing @@Vector3(0, 0, 1)@@.</para>
         /// </summary>
-        public static Vector3 forward
-        {
-            get
-            {
-                return new Vector3(0f, 0f, 1f);
-            }
-        }
+        public static Vector3 Forward => new Vector3(0f, 0f, 1f);
 
         /// <summary>
         ///   <para>Shorthand for writing @@Vector3(0, 0, -1)@@.</para>
         /// </summary>
-        public static Vector3 back
-        {
-            get
-            {
-                return new Vector3(0f, 0f, -1f);
-            }
-        }
+        public static Vector3 Back => new Vector3(0f, 0f, -1f);
 
         /// <summary>
         ///   <para>Shorthand for writing @@Vector3(0, 1, 0)@@.</para>
         /// </summary>
-        public static Vector3 up
-        {
-            get
-            {
-                return new Vector3(0f, 1f, 0f);
-            }
-        }
+        public static Vector3 Up => new Vector3(0f, 1f, 0f);
 
         /// <summary>
         ///   <para>Shorthand for writing @@Vector3(0, -1, 0)@@.</para>
         /// </summary>
-        public static Vector3 down
-        {
-            get
-            {
-                return new Vector3(0f, -1f, 0f);
-            }
-        }
+        public static Vector3 Down => new Vector3(0f, -1f, 0f);
 
         /// <summary>
         ///   <para>Shorthand for writing @@Vector3(-1, 0, 0)@@.</para>
         /// </summary>
-        public static Vector3 left
-        {
-            get
-            {
-                return new Vector3(-1f, 0f, 0f);
-            }
-        }
+        public static Vector3 Left => new Vector3(-1f, 0f, 0f);
 
         /// <summary>
         ///   <para>Shorthand for writing @@Vector3(1, 0, 0)@@.</para>
         /// </summary>
-        public static Vector3 right
-        {
-            get
-            {
-                return new Vector3(1f, 0f, 0f);
-            }
-        }
+        public static Vector3 Right => new Vector3(1f, 0f, 0f);
 
         /// <summary>
         ///   <para>Creates a new vector with given x, y, z components.</para>
@@ -238,12 +163,12 @@ namespace BSGO_Server._3dAlgorithm
         /// <param name="value"></param>
         public static Vector3 Normalize(Vector3 value)
         {
-            float num = Magnitude(value);
+            float num = GetMagnitude(value);
             if (num > 1E-05f)
             {
                 return value / num;
             }
-            return zero;
+            return Zero;
         }
 
         /// <summary>
@@ -251,14 +176,14 @@ namespace BSGO_Server._3dAlgorithm
         /// </summary>
         public void Normalize()
         {
-            float num = Magnitude(this);
+            float num = GetMagnitude(this);
             if (num > 1E-05f)
             {
                 this /= num;
             }
             else
             {
-                this = zero;
+                this = Zero;
             }
         }
 
@@ -277,68 +202,31 @@ namespace BSGO_Server._3dAlgorithm
         /// </summary>
         /// <param name="from">The angle extends round from this vector.</param>
         /// <param name="to">The angle extends round to this vector.</param>
-        public static float Angle(Vector3 from, Vector3 to)
-        {
-            return MathF.Acos(Math.Clamp(Dot(from.normalized, to.normalized), -1f, 1f)) * 57.29578f;
-        }
+        public static float Angle(Vector3 from, Vector3 to) => MathF.Acos(Math.Clamp(Dot(from.Normalized, to.Normalized), -1f, 1f)) * 57.29578f;
 
-        public static float Magnitude(Vector3 a)
-        {
-            return MathF.Sqrt(a.x * a.x + a.y * a.y + a.z * a.z);
-        }
+        public static float GetMagnitude(Vector3 a) => MathF.Sqrt(a.x * a.x + a.y * a.y + a.z * a.z);
 
-        public static float SqrMagnitude(Vector3 a)
-        {
-            return a.x * a.x + a.y * a.y + a.z * a.z;
-        }
+        public static float GetSqrMagnitude(Vector3 a) => a.x * a.x + a.y * a.y + a.z * a.z;
 
-        public static Vector3 operator +(Vector3 a, Vector3 b)
-        {
-            return new Vector3(a.x + b.x, a.y + b.y, a.z + b.z);
-        }
+        public static Vector3 operator +(Vector3 a, Vector3 b) => new Vector3(a.x + b.x, a.y + b.y, a.z + b.z);
 
-        public static Vector3 operator -(Vector3 a, Vector3 b)
-        {
-            return new Vector3(a.x - b.x, a.y - b.y, a.z - b.z);
-        }
+        public static Vector3 operator -(Vector3 a, Vector3 b) => new Vector3(a.x - b.x, a.y - b.y, a.z - b.z);
 
-        public static Vector3 operator -(Vector3 a)
-        {
-            return new Vector3(0f - a.x, 0f - a.y, 0f - a.z);
-        }
+        public static Vector3 operator -(Vector3 a) => new Vector3(0f - a.x, 0f - a.y, 0f - a.z);
 
-        public static Vector3 operator *(Vector3 a, float d)
-        {
-            return new Vector3(a.x * d, a.y * d, a.z * d);
-        }
+        public static Vector3 operator *(Vector3 a, float d) => new Vector3(a.x * d, a.y * d, a.z * d);
 
-        public static Vector3 operator *(float d, Vector3 a)
-        {
-            return new Vector3(a.x * d, a.y * d, a.z * d);
-        }
+        public static Vector3 operator *(float d, Vector3 a) => new Vector3(a.x * d, a.y * d, a.z * d);
 
-        public static Vector3 operator /(Vector3 a, float d)
-        {
-            return new Vector3(a.x / d, a.y / d, a.z / d);
-        }
+        public static Vector3 operator /(Vector3 a, float d) => new Vector3(a.x / d, a.y / d, a.z / d);
 
-        public static bool operator ==(Vector3 lhs, Vector3 rhs)
-        {
-            return SqrMagnitude(lhs - rhs) < 9.99999944E-11f;
-        }
+        public static bool operator ==(Vector3 lhs, Vector3 rhs) => GetSqrMagnitude(lhs - rhs) < 9.99999944E-11f;
 
-        public static bool operator !=(Vector3 lhs, Vector3 rhs)
-        {
-            return SqrMagnitude(lhs - rhs) >= 9.99999944E-11f;
-        }
+        public static bool operator !=(Vector3 lhs, Vector3 rhs) => GetSqrMagnitude(lhs - rhs) >= 9.99999944E-11f;
 
         /// <summary>
         ///   <para>Returns a nicely formatted string for this vector.</para>
         /// </summary>
-        /// <param name="format"></param>
-        public override string ToString()
-        {
-            return string.Format("({0:F1}, {1:F1}, {2:F1})", x, y, z);
-        }
+        public override string ToString() => string.Format("({0:F1}, {1:F1}, {2:F1})", x, y, z);
     }
 }

--- a/BSGO Server/BSGO Server/BSGO Server.csproj
+++ b/BSGO Server/BSGO Server/BSGO Server.csproj
@@ -2,10 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>BSGO_Server</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="2.9.2" />
   </ItemGroup>

--- a/BSGO Server/BSGO Server/Database/Database.cs
+++ b/BSGO Server/BSGO Server/Database/Database.cs
@@ -1,7 +1,6 @@
 ﻿using MongoDB.Driver;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using BSGO_Server.Database.Entities;
 using System.Linq.Expressions;
 
@@ -9,15 +8,15 @@ namespace BSGO_Server.Database
 {
     class Database
     {
-        private static IMongoClient client = new MongoClient("mongodb://localhost");
-        private static IMongoDatabase database = client.GetDatabase("bsgo");
-        private static IMongoCollection<Users> colUsers = database.GetCollection<Users>("users");
-        private static IMongoCollection<Characters> colCharacters = database.GetCollection<Characters>("characters");
+        private static readonly IMongoClient client = new MongoClient("mongodb://localhost");
+        private static readonly IMongoDatabase database = client.GetDatabase("bsgo");
+        private static readonly IMongoCollection<Users> colUsers = database.GetCollection<Users>("users");
+        private static readonly IMongoCollection<Characters> colCharacters = database.GetCollection<Characters>("characters");
 
         // This is temporary. Just making sure that my user does exist
-        private static Expression<Func<Users, bool>> filter =
+        private static readonly Expression<Func<Users, bool>> filter =
             x => x.PlayerId.Equals("5085935");
-        private static Users user = colUsers.Find(filter).FirstOrDefault();
+        private static readonly Users user = colUsers.Find(filter).FirstOrDefault();
 
         /// <summary>
         /// Initializes the database.
@@ -27,7 +26,7 @@ namespace BSGO_Server.Database
             // Since we want to use my premade user, we are making sure he is on the database at the start
             if (user == null)
             {
-                Users docUser = new Users() {
+                Users docUser = new Users {
                     PlayerId = "5085935",
                     SessionCode = "b1b23d2fa2769bd59d4c1b67554599b88381afd653b156aa54cb689969ab4fb7"
                 };
@@ -43,12 +42,12 @@ namespace BSGO_Server.Database
         /// <returns></returns>
         public static bool CheckSessionCodeExistance(string sessionCode)
         {
-            Expression<Func<Users, bool>> filter =
+            Expression<Func<Users, bool>> _filter =
                 x => x.SessionCode.Equals(sessionCode);
 
-            Users user = colUsers.Find(filter).FirstOrDefault();
+            Users _user = colUsers.Find(_filter).FirstOrDefault();
 
-            return user != null;
+            return _user != null;
         }
 
         /// <summary>
@@ -58,12 +57,12 @@ namespace BSGO_Server.Database
         /// <returns></returns>
         public static bool CheckPlayerExistanceById(string id)
         {
-            Expression<Func<Users, bool>> filter =
+            Expression<Func<Users, bool>> _filter =
                 x => x.PlayerId.Equals(id);
 
-            Users user = colUsers.Find(filter).FirstOrDefault();
+            Users _user = colUsers.Find(_filter).FirstOrDefault();
 
-            return user != null;
+            return _user != null;
         }
 
         /// <summary>
@@ -73,10 +72,10 @@ namespace BSGO_Server.Database
         /// <returns></returns>
         public static bool CheckCharacterExistanceById(string id)
         {
-            Expression<Func<Characters, bool>> filter =
+            Expression<Func<Characters, bool>> _filter =
                 x => x.PlayerId.Equals(id);
 
-            Characters character = colCharacters.Find(filter).FirstOrDefault();
+            Characters character = colCharacters.Find(_filter).FirstOrDefault();
 
             return character != null;
         }
@@ -88,10 +87,10 @@ namespace BSGO_Server.Database
         /// <returns></returns>
         public static bool CheckCharacterNameAvailability(string name)
         {
-            Expression<Func<Characters, bool>> filter =
+            Expression<Func<Characters, bool>> _filter =
                 x => x.Name.Equals(name);
 
-            Characters character = colCharacters.Find(filter).FirstOrDefault();
+            Characters character = colCharacters.Find(_filter).FirstOrDefault();
 
             return character == null;
         }
@@ -103,9 +102,9 @@ namespace BSGO_Server.Database
         /// <param name="playerId"></param>
         public static void CreateCharacter(string name, string playerId, byte faction, Dictionary<AvatarItem, string> items)
         {
-            Expression<Func<Characters, bool>> filter =
+            Expression<Func<Characters, bool>> _filter =
                 x => x.Name.Equals(name);
-            Characters character = colCharacters.Find(filter).FirstOrDefault();
+            Characters character = colCharacters.Find(_filter).FirstOrDefault();
 
             if (character != null)
                 return;
@@ -116,7 +115,7 @@ namespace BSGO_Server.Database
                 avatarItems.Add(item.Key.ToString(), item.Value);
             }
 
-            character = new Characters() {
+            character = new Characters {
                 Name = name,
                 GameLocation = 2,
                 Level = 1,
@@ -140,12 +139,12 @@ namespace BSGO_Server.Database
         /// <returns></returns>
         public static Users GetUserBySession(string session)
         {
-            Expression<Func<Users, bool>> filter =
+            Expression<Func<Users, bool>> _filter =
                 x => x.SessionCode.Equals(session);
 
-            Users user = colUsers.Find(filter).FirstOrDefault();
+            Users _user = colUsers.Find(_filter).FirstOrDefault();
 
-            return user;
+            return _user;
         }
 
         /// <summary>
@@ -155,10 +154,10 @@ namespace BSGO_Server.Database
         /// <returns></returns>
         public static Characters GetCharacterById(string id)
         {
-            Expression<Func<Characters, bool>> filter =
+            Expression<Func<Characters, bool>> _filter =
                 x => x.PlayerId.Equals(id);
 
-            Characters character = colCharacters.Find(filter).FirstOrDefault();
+            Characters character = colCharacters.Find(_filter).FirstOrDefault();
 
             return character;
         }

--- a/BSGO Server/BSGO Server/Database/Database.cs
+++ b/BSGO Server/BSGO Server/Database/Database.cs
@@ -135,7 +135,7 @@ namespace BSGO_Server.Database
         /// <summary>
         /// Returns a User(Database Entity) by searching his Session Code.
         /// </summary>
-        /// <param name="id"></param>
+        /// <param name="session"></param>
         /// <returns></returns>
         public static Users GetUserBySession(string session)
         {

--- a/BSGO Server/BSGO Server/Database/Entities/Characters.cs
+++ b/BSGO Server/BSGO Server/Database/Entities/Characters.cs
@@ -1,58 +1,56 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace BSGO_Server.Database.Entities
 {
-    class Characters
+    internal class Characters
     {
-        [BsonId()]
+        [BsonId]
         public ObjectId Id { get; set; }  
 
         [BsonElement("playerid")]
-        [BsonRequired()]
+        [BsonRequired]
         public string PlayerId { get; set; }
 
         [BsonElement("name")]
-        [BsonRequired()]
+        [BsonRequired]
         public string Name { get; set; }
 
         [BsonElement("gamelocation")]
-        [BsonRequired()]
+        [BsonRequired]
         public int GameLocation { get; set; }
 
         [BsonElement("level")]
-        [BsonRequired()]
+        [BsonRequired]
         public int Level { get; set; }
 
         [BsonElement("faction")]
-        [BsonRequired()]
+        [BsonRequired]
         public int Faction { get; set; }
 
         [BsonElement("avataritems")]
-        [BsonRequired()]
+        [BsonRequired]
         public Dictionary<string, string> AvatarItems { get; set; }
 
         [BsonElement("cubits")]
-        [BsonRequired()]
+        [BsonRequired]
         public string Cubits { get; set; }
 
         [BsonElement("water")]
-        [BsonRequired()]
+        [BsonRequired]
         public string Water { get; set; }
 
         [BsonElement("tylium")]
-        [BsonRequired()]
+        [BsonRequired]
         public string Tylium { get; set; }
 
         [BsonElement("titanium")]
-        [BsonRequired()]
+        [BsonRequired]
         public string Titanium { get; set; }
 
         [BsonElement("experience")]
-        [BsonRequired()]
+        [BsonRequired]
         public string Experience { get; set; }
 
         // Should have more later

--- a/BSGO Server/BSGO Server/Database/Entities/Users.cs
+++ b/BSGO Server/BSGO Server/Database/Entities/Users.cs
@@ -1,22 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using MongoDB.Bson;
+﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace BSGO_Server.Database.Entities
 {
-    class Users
+    internal class Users
     {
-        [BsonId()]
+        [BsonId]
         public ObjectId Id { get; set; }
 
         [BsonElement("playerid")]
-        [BsonRequired()]
+        [BsonRequired]
         public string PlayerId { get; set; }
 
         [BsonElement("sessioncode")]
-        [BsonRequired()]
+        [BsonRequired]
         public string SessionCode { get; set; }
 
         // Should have more later

--- a/BSGO Server/BSGO Server/Enums/AugmentActionType.cs
+++ b/BSGO Server/BSGO Server/Enums/AugmentActionType.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum AugmentActionType
+    internal enum AugmentActionType
     {
         None,
         SkillTime,

--- a/BSGO Server/BSGO Server/Enums/AvatarItem.cs
+++ b/BSGO Server/BSGO Server/Enums/AvatarItem.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum AvatarItem : byte
+    internal enum AvatarItem : byte
     {
         Race,
         Sex,

--- a/BSGO Server/BSGO Server/Enums/CardView.cs
+++ b/BSGO Server/BSGO Server/Enums/CardView.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum CardView : ushort
+    internal enum CardView : ushort
     {
         GUI = 1,
         ShipSystem = 2,

--- a/BSGO Server/BSGO Server/Enums/ConsumableEffectType.cs
+++ b/BSGO Server/BSGO Server/Enums/ConsumableEffectType.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum ConsumableEffectType
+    internal enum ConsumableEffectType
     {
         None,
         DamageKinetic,

--- a/BSGO Server/BSGO Server/Enums/CreatingCause.cs
+++ b/BSGO Server/BSGO Server/Enums/CreatingCause.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum CreatingCause : byte
+    internal enum CreatingCause : byte
     {
         AlreadyExists,
         JumpIn

--- a/BSGO Server/BSGO Server/Enums/Faction.cs
+++ b/BSGO Server/BSGO Server/Enums/Faction.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum Faction
+    internal enum Faction
     {
         Neutral,
         Colonial,

--- a/BSGO Server/BSGO Server/Enums/FactionGroup.cs
+++ b/BSGO Server/BSGO Server/Enums/FactionGroup.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum FactionGroup
+    internal enum FactionGroup
     {
         Group0,
         Group1

--- a/BSGO Server/BSGO Server/Enums/GameLocation.cs
+++ b/BSGO Server/BSGO Server/Enums/GameLocation.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum GameLocation : byte
+    internal enum GameLocation : byte
     {
         Unknown,
         Space,

--- a/BSGO Server/BSGO Server/Enums/ObjectStat.cs
+++ b/BSGO Server/BSGO Server/Enums/ObjectStat.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum ObjectStat : ushort
+    internal enum ObjectStat : ushort
     {
         None = 0,
         Accuracy = 2,

--- a/BSGO Server/BSGO Server/Enums/ShipAbilitySide.cs
+++ b/BSGO Server/BSGO Server/Enums/ShipAbilitySide.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum ShipAbilitySide : byte
+    internal enum ShipAbilitySide : byte
     {
         Self = 1,
         Any = 2,

--- a/BSGO Server/BSGO Server/Enums/ShipAbilityTarget.cs
+++ b/BSGO Server/BSGO Server/Enums/ShipAbilityTarget.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum ShipAbilityTarget
+    internal enum ShipAbilityTarget
     {
         Asteroid = 1,
         Ship = 2,

--- a/BSGO Server/BSGO Server/Enums/ShipRole.cs
+++ b/BSGO Server/BSGO Server/Enums/ShipRole.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum ShipRole : byte
+    internal enum ShipRole : byte
     {
         Fighter = 1,
         Bomber,

--- a/BSGO Server/BSGO Server/Enums/ShipRoleDeprecated.cs
+++ b/BSGO Server/BSGO Server/Enums/ShipRoleDeprecated.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum ShipRoleDeprecated : byte
+    internal enum ShipRoleDeprecated : byte
     {
         None,
         Fighter,

--- a/BSGO Server/BSGO Server/Enums/ShipSlotType.cs
+++ b/BSGO Server/BSGO Server/Enums/ShipSlotType.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum ShipSlotType : byte
+    internal enum ShipSlotType : byte
     {
         undefined,
         computer,

--- a/BSGO Server/BSGO Server/Enums/ShopCategory.cs
+++ b/BSGO Server/BSGO Server/Enums/ShopCategory.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum ShopCategory : byte
+    internal enum ShopCategory : byte
     {
         None,
         Resource,

--- a/BSGO Server/BSGO Server/Enums/ShopItemType.cs
+++ b/BSGO Server/BSGO Server/Enums/ShopItemType.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum ShopItemType
+    internal enum ShopItemType
     {
         None,
         Resource,

--- a/BSGO Server/BSGO Server/Enums/SpaceEntityType.cs
+++ b/BSGO Server/BSGO Server/Enums/SpaceEntityType.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum SpaceEntityType : uint
+    internal enum SpaceEntityType : uint
     {
         Player = 0x1000000,
         Missile = 0x2000000,

--- a/BSGO Server/BSGO Server/Enums/SpotType.cs
+++ b/BSGO Server/BSGO Server/Enums/SpotType.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum SpotType
+    internal enum SpotType
     {
         Weapon = 1,
         Sticker,

--- a/BSGO Server/BSGO Server/Enums/TargetBracketMode.cs
+++ b/BSGO Server/BSGO Server/Enums/TargetBracketMode.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
     public enum TargetBracketMode : byte
     {

--- a/BSGO Server/BSGO Server/Enums/TransSceneType.cs
+++ b/BSGO Server/BSGO Server/Enums/TransSceneType.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum TransSceneType
+    internal enum TransSceneType
     {
         None,
         Die,

--- a/BSGO Server/BSGO Server/Log.cs
+++ b/BSGO Server/BSGO Server/Log.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace BSGO_Server
 {
-    class Log
+    internal static class Log
     {
         public enum LogDir
         {
@@ -35,7 +33,7 @@ namespace BSGO_Server
                     break;
             }
 
-            finalText += "[" + System.DateTime.Now + "]";
+            finalText += "[" + DateTime.Now + "]";
             finalText += "[" + logDir +"] ";
 
             finalText += text;
@@ -68,7 +66,7 @@ namespace BSGO_Server
                     break;
             }
 
-            finalText += "[" + System.DateTime.Now + "] ";
+            finalText += "[" + DateTime.Now + "] ";
 
             finalText += text;
 

--- a/BSGO Server/BSGO Server/LogSeverity.cs
+++ b/BSGO Server/BSGO Server/LogSeverity.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    enum LogSeverity
+    internal enum LogSeverity
     {
         SERVERINFO,
         INFO,

--- a/BSGO Server/BSGO Server/Program.cs
+++ b/BSGO Server/BSGO Server/Program.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace BSGO_Server
 {
-    class Program
+    internal static class Program
     {
-        static async Task Main(string[] args)
+        private static async Task Main(string[] args)
         {
             // Since the original game was based on protocols, we have to first setup the server protocols
             // to receive/send what the game wants.

--- a/BSGO Server/BSGO Server/Server/Catalogue/AvatarCatalogueCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/AvatarCatalogueCard.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace BSGO_Server
 {
-    class AvatarCatalogueCard : Card
+    internal class AvatarCatalogueCard : Card
     {
-        public List<AvatarIndex> AvatarIndexes = new List<AvatarIndex>();
+        public List<AvatarIndex> AvatarIndexes { get; set; } = new List<AvatarIndex>();
 
         public AvatarCatalogueCard(uint cardGuid, CardView cardView)
             : base(cardGuid, cardView)
@@ -41,57 +39,67 @@ namespace BSGO_Server
             items.Add(itemName, itemNames);
 
             itemName = "beard";
-            itemNames = new List<string>();
-            itemNames.Add("volume_beard_empty");
-            itemNames.Add("volume_beard_01_01");
-            itemNames.Add("volume_beard_01_02");
-            itemNames.Add("volume_beard_02_01");
-            itemNames.Add("volume_beard_02_02");
-            itemNames.Add("volume_beard_02_03");
-            itemNames.Add("volume_beard_03_01");
-            itemNames.Add("volume_beard_03_03");
+            itemNames = new List<string>
+            {
+                "volume_beard_empty",
+                "volume_beard_01_01",
+                "volume_beard_01_02",
+                "volume_beard_02_01",
+                "volume_beard_02_02",
+                "volume_beard_02_03",
+                "volume_beard_03_01",
+                "volume_beard_03_03"
+            };
             items.Add(itemName, itemNames);
 
             itemName = "helmet";
-            itemNames = new List<string>();
-            itemNames.Add("helmet_empty");
-            itemNames.Add("helmet_01");
-            itemNames.Add("helmet_02");
-            itemNames.Add("helmet_03");
-            itemNames.Add("helmet_04");
-            itemNames.Add("helmet_05");
+            itemNames = new List<string>
+            {
+                "helmet_empty",
+                "helmet_01",
+                "helmet_02",
+                "helmet_03",
+                "helmet_04",
+                "helmet_05"
+            };
             items.Add(itemName, itemNames);
 
             itemName = "glasses";
-            itemNames = new List<string>();
-            itemNames.Add("glasses_empty");
-            itemNames.Add("glasses_01");
-            itemNames.Add("glasses_02");
-            itemNames.Add("glasses_03");
-            itemNames.Add("glasses_04");
-            itemNames.Add("glasses_05");
+            itemNames = new List<string>
+            {
+                "glasses_empty",
+                "glasses_01",
+                "glasses_02",
+                "glasses_03",
+                "glasses_04",
+                "glasses_05"
+            };
             items.Add(itemName, itemNames);
 
             itemName = "head";
-            itemNames = new List<string>();
-            itemNames.Add("male_head_01");
-            itemNames.Add("male_head_02");
-            itemNames.Add("male_head_03");
-            itemNames.Add("male_head_04");
-            itemNames.Add("male_head_05");
-            itemNames.Add("male_head_06");
-            itemNames.Add("male_head_08");
-            itemNames.Add("male_head_09");
-            itemNames.Add("male_head_10");
+            itemNames = new List<string>
+            {
+                "male_head_01",
+                "male_head_02",
+                "male_head_03",
+                "male_head_04",
+                "male_head_05",
+                "male_head_06",
+                "male_head_08",
+                "male_head_09",
+                "male_head_10"
+            };
             items.Add(itemName, itemNames);
 
             itemName = "suit";
-            itemNames = new List<string>();
-            itemNames.Add("male_suit_01");
-            itemNames.Add("male_suit_02");
-            itemNames.Add("male_suit_03");
-            itemNames.Add("male_suit_04");
-            itemNames.Add("male_suit_06");
+            itemNames = new List<string>
+            {
+                "male_suit_01",
+                "male_suit_02",
+                "male_suit_03",
+                "male_suit_04",
+                "male_suit_06"
+            };
             items.Add(itemName, itemNames);
 
             textureName = "faces_tex";
@@ -108,17 +116,19 @@ namespace BSGO_Server
             textures.Add(textureName, textureNames);
 
             textureName = "hands_tex";
-            textureNames = new List<string>();
-            textureNames.Add("male_hands1.png");
-            textureNames.Add("male_hands2.png");
-            textureNames.Add("male_hands3.png");
-            textureNames.Add("male_hands4.png");
-            textureNames.Add("male_hands5.png");
-            textureNames.Add("male_hands6.png");
-            textureNames.Add("male_hands7.png");
-            textureNames.Add("male_hands8.png");
-            textureNames.Add("male_hands9.png");
-            textureNames.Add("male_hands10.png");
+            textureNames = new List<string>
+            {
+                "male_hands1.png",
+                "male_hands2.png",
+                "male_hands3.png",
+                "male_hands4.png",
+                "male_hands5.png",
+                "male_hands6.png",
+                "male_hands7.png",
+                "male_hands8.png",
+                "male_hands9.png",
+                "male_hands10.png"
+            };
             textures.Add(textureName, textureNames);
 
             materialName = "hair_";
@@ -131,157 +141,189 @@ namespace BSGO_Server
             submaterialNames.Add("male_hair_01_7.mat");
             submaterials.Add("male_hair_01", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("male_hair_02_1.mat");
-            submaterialNames.Add("male_hair_02_2.mat");
-            submaterialNames.Add("male_hair_02_3.mat");
-            submaterialNames.Add("male_hair_02_4.mat");
-            submaterialNames.Add("male_hair_02_5.mat");
-            submaterialNames.Add("male_hair_02_6.mat");
-            submaterialNames.Add("male_hair_02_7.mat");
+            submaterialNames = new List<string>
+            {
+                "male_hair_02_1.mat",
+                "male_hair_02_2.mat",
+                "male_hair_02_3.mat",
+                "male_hair_02_4.mat",
+                "male_hair_02_5.mat",
+                "male_hair_02_6.mat",
+                "male_hair_02_7.mat"
+            };
             submaterials.Add("male_hair_02", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("male_hair_03_1.mat");
-            submaterialNames.Add("male_hair_03_2.mat");
-            submaterialNames.Add("male_hair_03_3.mat");
-            submaterialNames.Add("male_hair_03_4.mat");
-            submaterialNames.Add("male_hair_03_5.mat");
-            submaterialNames.Add("male_hair_03_6.mat");
-            submaterialNames.Add("male_hair_03_7.mat");
+            submaterialNames = new List<string>
+            {
+                "male_hair_03_1.mat",
+                "male_hair_03_2.mat",
+                "male_hair_03_3.mat",
+                "male_hair_03_4.mat",
+                "male_hair_03_5.mat",
+                "male_hair_03_6.mat",
+                "male_hair_03_7.mat"
+            };
             submaterials.Add("male_hair_03", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("male_hair_04_1.mat");
-            submaterialNames.Add("male_hair_04_2.mat");
-            submaterialNames.Add("male_hair_04_3.mat");
-            submaterialNames.Add("male_hair_04_4.mat");
-            submaterialNames.Add("male_hair_04_5.mat");
-            submaterialNames.Add("male_hair_04_6.mat");
-            submaterialNames.Add("male_hair_04_7.mat");
+            submaterialNames = new List<string>
+            {
+                "male_hair_04_1.mat",
+                "male_hair_04_2.mat",
+                "male_hair_04_3.mat",
+                "male_hair_04_4.mat",
+                "male_hair_04_5.mat",
+                "male_hair_04_6.mat",
+                "male_hair_04_7.mat"
+            };
             submaterials.Add("male_hair_04", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("male_hair_05_1.mat");
-            submaterialNames.Add("male_hair_05_2.mat");
-            submaterialNames.Add("male_hair_05_3.mat");
-            submaterialNames.Add("male_hair_05_4.mat");
-            submaterialNames.Add("male_hair_05_5.mat");
-            submaterialNames.Add("male_hair_05_6.mat");
-            submaterialNames.Add("male_hair_05_7.mat");
+            submaterialNames = new List<string>
+            {
+                "male_hair_05_1.mat",
+                "male_hair_05_2.mat",
+                "male_hair_05_3.mat",
+                "male_hair_05_4.mat",
+                "male_hair_05_5.mat",
+                "male_hair_05_6.mat",
+                "male_hair_05_7.mat"
+            };
             submaterials.Add("male_hair_05", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("male_hair_06_1.mat");
-            submaterialNames.Add("male_hair_06_2.mat");
-            submaterialNames.Add("male_hair_06_3.mat");
-            submaterialNames.Add("male_hair_06_4.mat");
-            submaterialNames.Add("male_hair_06_5.mat");
-            submaterialNames.Add("male_hair_06_6.mat");
-            submaterialNames.Add("male_hair_06_7.mat");
+            submaterialNames = new List<string>
+            {
+                "male_hair_06_1.mat",
+                "male_hair_06_2.mat",
+                "male_hair_06_3.mat",
+                "male_hair_06_4.mat",
+                "male_hair_06_5.mat",
+                "male_hair_06_6.mat",
+                "male_hair_06_7.mat"
+            };
             submaterials.Add("male_hair_06", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("male_hair_07_1.mat");
-            submaterialNames.Add("male_hair_07_2.mat");
-            submaterialNames.Add("male_hair_07_3.mat");
-            submaterialNames.Add("male_hair_07_4.mat");
-            submaterialNames.Add("male_hair_07_5.mat");
-            submaterialNames.Add("male_hair_07_6.mat");
-            submaterialNames.Add("male_hair_07_7.mat");
+            submaterialNames = new List<string>
+            {
+                "male_hair_07_1.mat",
+                "male_hair_07_2.mat",
+                "male_hair_07_3.mat",
+                "male_hair_07_4.mat",
+                "male_hair_07_5.mat",
+                "male_hair_07_6.mat",
+                "male_hair_07_7.mat"
+            };
             submaterials.Add("male_hair_07", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("male_hair_08_1.mat");
-            submaterialNames.Add("male_hair_08_2.mat");
-            submaterialNames.Add("male_hair_08_3.mat");
-            submaterialNames.Add("male_hair_08_4.mat");
-            submaterialNames.Add("male_hair_08_5.mat");
-            submaterialNames.Add("male_hair_08_6.mat");
-            submaterialNames.Add("male_hair_08_7.mat");
+            submaterialNames = new List<string>
+            {
+                "male_hair_08_1.mat",
+                "male_hair_08_2.mat",
+                "male_hair_08_3.mat",
+                "male_hair_08_4.mat",
+                "male_hair_08_5.mat",
+                "male_hair_08_6.mat",
+                "male_hair_08_7.mat"
+            };
             submaterials.Add("male_hair_08", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("male_hair_09_1.mat");
-            submaterialNames.Add("male_hair_09_2.mat");
-            submaterialNames.Add("male_hair_09_3.mat");
-            submaterialNames.Add("male_hair_09_4.mat");
-            submaterialNames.Add("male_hair_09_5.mat");
-            submaterialNames.Add("male_hair_09_6.mat");
-            submaterialNames.Add("male_hair_09_7.mat");
+            submaterialNames = new List<string>
+            {
+                "male_hair_09_1.mat",
+                "male_hair_09_2.mat",
+                "male_hair_09_3.mat",
+                "male_hair_09_4.mat",
+                "male_hair_09_5.mat",
+                "male_hair_09_6.mat",
+                "male_hair_09_7.mat"
+            };
             submaterials.Add("male_hair_09", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("male_hair_10_1.mat");
-            submaterialNames.Add("male_hair_10_2.mat");
-            submaterialNames.Add("male_hair_10_3.mat");
-            submaterialNames.Add("male_hair_10_4.mat");
-            submaterialNames.Add("male_hair_10_5.mat");
-            submaterialNames.Add("male_hair_10_6.mat");
-            submaterialNames.Add("male_hair_10_7.mat");
+            submaterialNames = new List<string>
+            {
+                "male_hair_10_1.mat",
+                "male_hair_10_2.mat",
+                "male_hair_10_3.mat",
+                "male_hair_10_4.mat",
+                "male_hair_10_5.mat",
+                "male_hair_10_6.mat",
+                "male_hair_10_7.mat"
+            };
             submaterials.Add("male_hair_10", submaterialNames);
 
             materials.Add(materialName, submaterials);
 
             materialName = "beard_";
             submaterials = new Dictionary<string, List<string>>();
-            submaterialNames = new List<string>();
-            submaterialNames.Add("volume_beard_01");
-            submaterialNames.Add("volume_beard_01_01_1");
-            submaterialNames.Add("volume_beard_01_01_2");
-            submaterialNames.Add("volume_beard_01_01_3");
-            submaterialNames.Add("volume_beard_01_01_4");
-            submaterialNames.Add("volume_beard_01_01_5");
+            submaterialNames = new List<string>
+            {
+                "volume_beard_01",
+                "volume_beard_01_01_1",
+                "volume_beard_01_01_2",
+                "volume_beard_01_01_3",
+                "volume_beard_01_01_4",
+                "volume_beard_01_01_5"
+            };
             submaterials.Add("volume_beard_01_01", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("volume_beard_01_02_1");
-            submaterialNames.Add("volume_beard_01_02_2");
-            submaterialNames.Add("volume_beard_01_02_3");
-            submaterialNames.Add("volume_beard_01_02_4");
-            submaterialNames.Add("volume_beard_01_02_5");
+            submaterialNames = new List<string>
+            {
+                "volume_beard_01_02_1",
+                "volume_beard_01_02_2",
+                "volume_beard_01_02_3",
+                "volume_beard_01_02_4",
+                "volume_beard_01_02_5"
+            };
             submaterials.Add("volume_beard_01_02", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("volume_beard_02");
-            submaterialNames.Add("volume_beard_02_01_1");
-            submaterialNames.Add("volume_beard_02_01_2");
-            submaterialNames.Add("volume_beard_02_01_3");
-            submaterialNames.Add("volume_beard_02_01_4");
-            submaterialNames.Add("volume_beard_02_01_5");
+            submaterialNames = new List<string>
+            {
+                "volume_beard_02",
+                "volume_beard_02_01_1",
+                "volume_beard_02_01_2",
+                "volume_beard_02_01_3",
+                "volume_beard_02_01_4",
+                "volume_beard_02_01_5"
+            };
             submaterials.Add("volume_beard_02_01", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("volume_beard_02_02_1");
-            submaterialNames.Add("volume_beard_02_02_2");
-            submaterialNames.Add("volume_beard_02_02_3");
-            submaterialNames.Add("volume_beard_02_02_4");
-            submaterialNames.Add("volume_beard_02_02_5");
+            submaterialNames = new List<string>
+            {
+                "volume_beard_02_02_1",
+                "volume_beard_02_02_2",
+                "volume_beard_02_02_3",
+                "volume_beard_02_02_4",
+                "volume_beard_02_02_5"
+            };
             submaterials.Add("volume_beard_02_02", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("volume_beard_02_03_1");
-            submaterialNames.Add("volume_beard_02_03_2");
-            submaterialNames.Add("volume_beard_02_03_3");
-            submaterialNames.Add("volume_beard_02_03_4");
-            submaterialNames.Add("volume_beard_02_03_5");
+            submaterialNames = new List<string>
+            {
+                "volume_beard_02_03_1",
+                "volume_beard_02_03_2",
+                "volume_beard_02_03_3",
+                "volume_beard_02_03_4",
+                "volume_beard_02_03_5"
+            };
             submaterials.Add("volume_beard_02_03", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("volume_beard_03");
-            submaterialNames.Add("volume_beard_03_01_1");
-            submaterialNames.Add("volume_beard_03_01_2");
-            submaterialNames.Add("volume_beard_03_01_3");
-            submaterialNames.Add("volume_beard_03_01_4");
-            submaterialNames.Add("volume_beard_03_01_5");
+            submaterialNames = new List<string>
+            {
+                "volume_beard_03",
+                "volume_beard_03_01_1",
+                "volume_beard_03_01_2",
+                "volume_beard_03_01_3",
+                "volume_beard_03_01_4",
+                "volume_beard_03_01_5"
+            };
             submaterials.Add("volume_beard_03_01", submaterialNames);
 
-            submaterialNames = new List<string>();
-            submaterialNames.Add("volume_beard_03_03_1");
-            submaterialNames.Add("volume_beard_03_03_2");
-            submaterialNames.Add("volume_beard_03_03_3");
-            submaterialNames.Add("volume_beard_03_03_4");
-            submaterialNames.Add("volume_beard_03_03_5");
+            submaterialNames = new List<string>
+            {
+                "volume_beard_03_03_1",
+                "volume_beard_03_03_2",
+                "volume_beard_03_03_3",
+                "volume_beard_03_03_4",
+                "volume_beard_03_03_5"
+            };
             submaterials.Add("volume_beard_03_03", submaterialNames);
 
             materials.Add(materialName, submaterials);
@@ -295,9 +337,7 @@ namespace BSGO_Server
             base.Write(w);
             w.Write((ushort)AvatarIndexes.Count);
             foreach(AvatarIndex ai in AvatarIndexes)
-            {
                 ai.Write(w);
-            }
         }
     }
 }

--- a/BSGO Server/BSGO Server/Server/Catalogue/CameraCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/CameraCard.cs
@@ -1,16 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class CameraCard : Card
+    internal class CameraCard : Card
     {
-        public float DefaultZoom = 1f;
-        public float MinZoom = 10f;
-        public float MaxZoom = 20f;
-        public float SoftTrembleSpeed = 1f;
-        public float HardTrembleSpeed = 1f;
+        public float DefaultZoom { get; set; } = 1f;
+        public float MinZoom { get; set; } = 10f;
+        public float MaxZoom { get; set; } = 20f;
+        public float SoftTrembleSpeed { get; set; } = 1f;
+        public float HardTrembleSpeed { get; set; } = 1f;
 
         public CameraCard(uint cardGUID, CardView cardView, float defaultZoom, float minZoom, float maxZoom, float softTrembleSpeed, float hardTrembleSpeed)
             : base(cardGUID, cardView)

--- a/BSGO Server/BSGO Server/Server/Catalogue/Card.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Card.cs
@@ -1,46 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    abstract class Card : IProtocolWrite
+    internal abstract class Card : IProtocolWrite
     {
-        private uint cardGUID;
-        private CardView cardView;
-        public uint CardGUID
-        {
-            get
-            {
-                return cardGUID;
-            }
-            set
-            {
-                cardGUID = value;
-            }
-        }
-        public CardView CardView
-        {
-            get
-            {
-                return cardView;
-            }
-            set
-            {
-                cardView = value;
-            }
-        }
+        public uint CardGUID { get; set; }
+        public CardView CardView { get; set; }
 
-        public Card(uint cardGUID, CardView cardView)
+        protected Card(uint cardGUID, CardView cardView)
         {
-            this.cardGUID = cardGUID;
-            this.cardView = cardView;
+            CardGUID = cardGUID;
+            CardView = cardView;
         }
 
         public virtual void Write(BgoProtocolWriter w)
         {
-            w.Write(cardGUID);
-            w.Write((ushort)cardView);
+            w.Write(CardGUID);
+            w.Write((ushort)CardView);
         }
     }
 }

--- a/BSGO Server/BSGO Server/Server/Catalogue/Catalogue.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Catalogue.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Drawing;
 using System.Numerics;
 
 namespace BSGO_Server
 {
-    class Catalogue
+    internal static class Catalogue
     {
-        private static Dictionary<long, Card> cards = new Dictionary<long, Card>();
+        private static readonly Dictionary<long, Card> cards = new Dictionary<long, Card>();
 
         // This method will generate all "static" cards that the server is going to send to the client.
         public static void SetupCards()
@@ -21,8 +19,8 @@ namespace BSGO_Server
 
             // These two cards shouldn't be static since they are most likely set according to the database.
             // Since we are just debugging this, there's no need to hook it up even with the fake database yet.
-            GUICard colonialBonus = new GUICard(colonialBonusReward.CardGUID, CardView.GUI, "bonus_faction_balance_neutral", (byte)0, "", 0, "", "", "", new string[0]);
-            GUICard cylonBonus = new GUICard(cylonBonusReward.CardGUID, CardView.GUI, "bonus_faction_balance_neutral", (byte)0, "", 0, "", "", "", new string[0]);
+            GUICard colonialBonus = new GUICard(colonialBonusReward.CardGUID, CardView.GUI, "bonus_faction_balance_neutral", 0, "", 0, "", "", "", new string[0]);
+            GUICard cylonBonus = new GUICard(cylonBonusReward.CardGUID, CardView.GUI, "bonus_faction_balance_neutral", 0, "", 0, "", "", "", new string[0]);
 
             AddCard(colonialBonus);
             AddCard(cylonBonus);
@@ -127,17 +125,14 @@ namespace BSGO_Server
         public static Card FetchCard(uint cardGUID, CardView cardView)
         {
             if (cardGUID == 0)
-            {
                 return null;
-            }
+            
             Log.Add(LogSeverity.WARNING, string.Format("Received a card request: CardGUID={0}, CardView={1}", cardGUID, cardView));
 
             long key = GenerateKey(cardGUID, cardView);
-            Card value;
-            if (!cards.TryGetValue(key, out value))
-            {
+            if (!cards.TryGetValue(key, out Card value))
                 Log.Add(LogSeverity.ERROR, string.Format("The {0}CardView({1}) isn't on the cards dictionary.", cardView, cardGUID));
-            }
+            
             return value;
         }
 

--- a/BSGO Server/BSGO Server/Server/Catalogue/GUICard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/GUICard.cs
@@ -1,26 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class GUICard : Card
+    internal class GUICard : Card
     {
-        public string Key = string.Empty;
+        public string Key { get; set; } = string.Empty;
 
-        public byte Level;
+        public byte Level { get; set; }
 
-        private string[] Args;
+        private readonly string[] args;
 
-        public string GUIIcon;
+        public string GUIIcon { get; set; }
 
-        public string GUITexturePath = string.Empty;
+        public string GUITexturePath { get; set; } = string.Empty;
 
-        public string GUIAtlasTexturePath = string.Empty;
+        public string GUIAtlasTexturePath { get; set; } = string.Empty;
 
-        public string GUIAvatarSlotTexturePath = string.Empty;
+        public string GUIAvatarSlotTexturePath { get; set; } = string.Empty;
 
-        public ushort FrameIndex;
+        public ushort FrameIndex { get; set; }
 
         public GUICard(uint cardGUID, CardView cardView, string key, byte level, string GUIAtlasTexturePath, ushort frameIndex, string GUIIcon, string GUIAvatarSlotTexturePath, string GUITexturePath, string[] args)
             : base(cardGUID, cardView)
@@ -32,7 +28,7 @@ namespace BSGO_Server
             this.GUIIcon = GUIIcon;
             this.GUIAvatarSlotTexturePath = GUIAvatarSlotTexturePath;
             this.GUITexturePath = GUITexturePath;
-            Args = args;
+            this.args = args;
         }
 
         public override void Write(BgoProtocolWriter w)
@@ -45,7 +41,7 @@ namespace BSGO_Server
             w.Write(GUIIcon);
             w.Write(GUIAvatarSlotTexturePath);
             w.Write(GUITexturePath);
-            w.Write(Args);
+            w.Write(args);
         }
     }
 }

--- a/BSGO Server/BSGO Server/Server/Catalogue/GalaxyMapCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/GalaxyMapCard.cs
@@ -1,16 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace BSGO_Server
 {
-    class GalaxyMapCard : Card
+    internal class GalaxyMapCard : Card
     {
-        public Dictionary<uint, MapStarDesc> Stars = new Dictionary<uint, MapStarDesc>();
+        public Dictionary<uint, MapStarDesc> Stars { get; set; } = new Dictionary<uint, MapStarDesc>();
 
-        public int[] Tiers;
+        public int[] Tiers { get; set; }
 
-        public int BaseScalingMultiplier;
+        public int BaseScalingMultiplier { get; set; }
 
         public GalaxyMapCard(uint cardGUID, CardView cardView, Dictionary<uint, MapStarDesc> stars, int[] tiers, int baseScalingMultiplier)
             : base(cardGUID, cardView)
@@ -42,9 +40,8 @@ namespace BSGO_Server
             w.Write(200);
         }
 
-        public MapStarDesc GetStar(uint sectorId)
-        {
-            return Stars[sectorId];
-        }
+        public MapStarDesc GetStar(uint sectorId) =>
+            Stars[sectorId];
+        
     }
 }

--- a/BSGO Server/BSGO Server/Server/Catalogue/GlobalCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/GlobalCard.cs
@@ -1,20 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace BSGO_Server
 {
-    class GlobalCard : Card
+    internal class GlobalCard : Card
     {
-        public float TitaniumRepairCard = 1f;
-        public float CubitsRepairCard = 1f;
-        public uint CapitalShipPrice;
-        public float UndockTimeout;
-        public RewardCard FriendBonus;
-        public Dictionary<int, RewardCard> SpecialFriendBonus = new Dictionary<int, RewardCard>();
+        public float TitaniumRepairCard { get; set; } = 1f;
+        public float CubitsRepairCard { get; set; } = 1f;
+        public uint CapitalShipPrice { get; set; }
+        public float UndockTimeout { get; set; }
+        public RewardCard FriendBonus { get; set; }
+        public Dictionary<int, RewardCard> SpecialFriendBonus { get; set; } = new Dictionary<int, RewardCard>();
 
         public GlobalCard(uint cardGUID, CardView cardView, float titaniumRepairCard, float cubitsRepairCard, uint capitalShipPrice, float undockTimeout, RewardCard friendBonus, Dictionary<int, RewardCard> specialFriendBonus)
-    : base(cardGUID, cardView)
+            : base(cardGUID, cardView)
         {
             TitaniumRepairCard = titaniumRepairCard;
             CubitsRepairCard = cubitsRepairCard;
@@ -33,6 +31,7 @@ namespace BSGO_Server
             w.Write(UndockTimeout);
             w.Write(FriendBonus.CardGUID);
             w.Write(SpecialFriendBonus.Count);
+
             foreach (KeyValuePair<int, RewardCard> friendBonus in SpecialFriendBonus)
             {
                 w.Write((byte)friendBonus.Key);

--- a/BSGO Server/BSGO Server/Server/Catalogue/MovementCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/MovementCard.cs
@@ -1,48 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class MovementCard : Card
+    internal class MovementCard : Card
     {
-        public float minYawSpeed = 3f;
+        public float MinYawSpeed { get; set; } = 3f;
 
-        public float maxPitch = 55f;
+        public float MaxPitch { get; set; } = 55f;
 
-        public float maxRoll = 50f;
+        public float MaxRoll { get; set; } = 50f;
 
-        public float pitchFading = 0.3f;
+        public float PitchFading { get; set; } = 0.3f;
 
-        public float yawFading = 0.3f;
+        public float YawFading { get; set; } = 0.3f;
 
-        public float rollFading = 0.6f;
+        public float RollFading { get; set; } = 0.6f;
 
         public MovementCard(uint cardGUID, CardView cardView)
-            : base(cardGUID, cardView)
-        {
-        }
+            : base(cardGUID, cardView) { }
 
         public MovementCard(uint cardGUID, CardView cardView, float minYawSpeed, float maxPitch, float maxRoll, float pitchFading, float yawFading, float rollFading)
             : base(cardGUID, cardView)
         {
-            this.minYawSpeed = minYawSpeed;
-            this.maxPitch = maxPitch;
-            this.maxRoll = maxRoll;
-            this.pitchFading = pitchFading;
-            this.yawFading = yawFading;
-            this.rollFading = rollFading;
+            MinYawSpeed = minYawSpeed;
+            MaxPitch = maxPitch;
+            MaxRoll = maxRoll;
+            PitchFading = pitchFading;
+            YawFading = yawFading;
+            RollFading = rollFading;
         }
 
         public override void Write(BgoProtocolWriter w)
         {
             base.Write(w);
-            w.Write(minYawSpeed);
-            w.Write(maxPitch);
-            w.Write(maxRoll);
-            w.Write(pitchFading);
-            w.Write(yawFading);
-            w.Write(rollFading);
+            w.Write(MinYawSpeed);
+            w.Write(MaxPitch);
+            w.Write(MaxRoll);
+            w.Write(PitchFading);
+            w.Write(YawFading);
+            w.Write(RollFading);
         }
     }
 }

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/AvatarIndex.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/AvatarIndex.cs
@@ -1,48 +1,46 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace BSGO_Server
 {
-    class AvatarIndex : IProtocolWrite
+    internal class AvatarIndex : IProtocolWrite
     {
-        public string race;
+        public string Race { get; set; }
 
-        public string sex;
+        public string Sex { get; set; }
 
-        public Dictionary<string, List<string>> items = new Dictionary<string, List<string>>();
+        public Dictionary<string, List<string>> Items { get; set; } = new Dictionary<string, List<string>>();
 
-        public Dictionary<string, List<string>> textures = new Dictionary<string, List<string>>();
+        public Dictionary<string, List<string>> Textures { get; set; } = new Dictionary<string, List<string>>();
 
-        public Dictionary<string, Dictionary<string, List<string>>> materials = new Dictionary<string, Dictionary<string, List<string>>>();
+        public Dictionary<string, Dictionary<string, List<string>>> Materials { get; set; } = new Dictionary<string, Dictionary<string, List<string>>>();
 
         public AvatarIndex(string race, string sex, Dictionary<string, List<string>> items, Dictionary<string, List<string>> textures, Dictionary<string, Dictionary<string, List<string>>> materials)
         {
-            this.race = race;
-            this.sex = sex;
-            this.items = items;
-            this.textures = textures;
-            this.materials = materials;
+            Race = race;
+            Sex = sex;
+            Items = items;
+            Textures = textures;
+            Materials = materials;
         }
 
         public void Write(BgoProtocolWriter w)
         {
-            w.Write(sex);
-            w.Write(race);
-            w.Write((ushort)items.Count);
-            foreach (KeyValuePair<string, List<string>> pair in items)
+            w.Write(Sex);
+            w.Write(Race);
+            w.Write((ushort)Items.Count);
+            foreach (KeyValuePair<string, List<string>> pair in Items)
             {
                 w.Write(pair.Key);
                 int pairCount = pair.Value.Count;
                 w.Write((ushort)pairCount);
                 for(int i = 0; i < pairCount; i++)
-                {
                     w.Write(pair.Value[i]);
-                }
+                
             }
 
-            w.Write((ushort)materials.Count);
-            foreach (KeyValuePair<string, Dictionary<string, List<string>>> pair in materials)
+            w.Write((ushort)Materials.Count);
+
+            foreach (KeyValuePair<string, Dictionary<string, List<string>>> pair in Materials)
             {
                 w.Write(pair.Key);
                 w.Write((ushort)pair.Value.Count);
@@ -53,22 +51,21 @@ namespace BSGO_Server
                     int pair2Count = pair2.Value.Count;
                     w.Write((ushort)pair2Count);
                     for (int i = 0; i < pair2Count; i++)
-                    {
                         w.Write(pair2.Value[i]);
-                    }
+                    
                 }
             }
 
-            w.Write((ushort)textures.Count);
-            foreach (KeyValuePair<string, List<string>> pair3 in textures)
+            w.Write((ushort)Textures.Count);
+
+            foreach (KeyValuePair<string, List<string>> pair3 in Textures)
             {
                 w.Write(pair3.Key);
                 int pairCount = pair3.Value.Count;
                 w.Write((ushort)pairCount);
                 for (int i = 0; i < pairCount; i++)
-                {
                     w.Write(pair3.Value[i]);
-                }
+                
             }
         }
     }

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/BackgroundDesc.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/BackgroundDesc.cs
@@ -1,32 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
+﻿using System.Drawing;
 using System.Numerics;
-using System.Text;
 
 namespace BSGO_Server
 {
-    class BackgroundDesc : IProtocolWrite
+    internal class BackgroundDesc : IProtocolWrite
     {
-        public string prefabName;
-        public Quaternion rotation;
-        public Color color;
-        public Vector3 position;
+        public string PrefabName { get; set; }
+        public Quaternion Rotation { get; set; }
+        public Color Color { get; set; }
+        public Vector3 Position { get; set; }
 
         public BackgroundDesc(string prefabName, Quaternion rotation, Color color, Vector3 position)
         {
-            this.prefabName = prefabName;
-            this.rotation = rotation;
-            this.color = color;
-            this.position = position;
+            PrefabName = prefabName;
+            Rotation = rotation;
+            Color = color;
+            Position = position;
         }
 
         public void Write(BgoProtocolWriter w)
         {
-            w.Write(prefabName);
-            w.Write(rotation);
-            w.Write(color);
-            w.Write(position);
+            w.Write(PrefabName);
+            w.Write(Rotation);
+            w.Write(Color);
+            w.Write(Position);
         }
     }
 }

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/ConsumableAttribute.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/ConsumableAttribute.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class ConsumableAttribute
+    internal class ConsumableAttribute
     {
-        public string Attribute;
+        public string Attribute { get; set; }
 
         public ConsumableAttribute(string attribute)
         {

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/JCameraFx.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/JCameraFx.cs
@@ -1,21 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class JCameraFx : IProtocolWrite
+    internal class JCameraFx : IProtocolWrite
     {
-        public bool ForceDisableBloom;
+        public bool ForceDisableBloom { get; set; }
 
         public JCameraFx(bool forceDisableBloom)
         {
             ForceDisableBloom = forceDisableBloom;
         }
 
-        public void Write(BgoProtocolWriter w)
-        {
+        public void Write(BgoProtocolWriter w) =>
             w.Write(ForceDisableBloom);
-        }
+        
     }
 }

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/JCameraFx.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/JCameraFx.cs
@@ -4,13 +4,10 @@
     {
         public bool ForceDisableBloom { get; set; }
 
-        public JCameraFx(bool forceDisableBloom)
-        {
+        public JCameraFx(bool forceDisableBloom) =>
             ForceDisableBloom = forceDisableBloom;
-        }
-
-        public void Write(BgoProtocolWriter w) =>
-            w.Write(ForceDisableBloom);
         
+        public void Write(BgoProtocolWriter w) =>
+            w.Write(ForceDisableBloom);   
     }
 }

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/JGlobalFog.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/JGlobalFog.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Text;
+﻿using System.Drawing;
 
 namespace BSGO_Server
 {
     class JGlobalFog : IProtocolWrite
     {
-        public bool Enabled;
-        public Color Color; //= new Color(0.427f, 0.534f, 0.538f, 0.314f);
-        public float Density = 0.0015f;
-        public float StartDistance;
+        public bool Enabled { get; set; }
+        public Color Color { get; set; } //= new Color(0.427f, 0.534f, 0.538f, 0.314f);
+        public float Density { get; set; } = 0.0015f;
+        public float StartDistance { get; set; }
 
         public JGlobalFog(bool enabled, Color color, float density, float startDistance)
         {

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/LightDesc.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/LightDesc.cs
@@ -1,29 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
+﻿using System.Drawing;
 using System.Numerics;
-using System.Text;
 
 namespace BSGO_Server
 {
-    class LightDesc : IProtocolWrite
+    internal class LightDesc : IProtocolWrite
     {
-        public Quaternion rotation;
-        public Color color;
-        public float intensity;
+        public Quaternion Rotation { get; set; }
+        public Color Color { get; set; }
+        public float Intensity { get; set; }
 
         public LightDesc(Quaternion rotation, Color color, float intensity)
         {
-            this.rotation = rotation;
-            this.color = color;
-            this.intensity = intensity;
+            Rotation = rotation;
+            Color = color;
+            Intensity = intensity;
         }
 
         public void Write(BgoProtocolWriter w)
         {
-            w.Write(rotation);
-            w.Write(color);
-            w.Write(intensity);
+            w.Write(Rotation);
+            w.Write(Color);
+            w.Write(Intensity);
         }
     }
 }

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/MapStarDesc.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/MapStarDesc.cs
@@ -1,33 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Numerics;
-using System.Text;
+﻿using System.Numerics;
 
 namespace BSGO_Server
 {
-    class MapStarDesc : IProtocolWrite
+    internal class MapStarDesc : IProtocolWrite
     {
-        public uint Id;
+        public uint Id { get; set; }
 
-        public Vector2 Position;
+        public Vector2 Position { get; set; }
 
-        public byte GUIIndex;
+        public byte GUIIndex { get; set; }
 
-        public Faction StarFaction;
+        public Faction StarFaction { get; set; }
 
-        public int ColonialThreatLevel;
+        public int ColonialThreatLevel { get; set; }
 
-        public int CylonThreatLevel;
+        public int CylonThreatLevel { get; set; }
 
-        public uint SectorGUID;
+        public uint SectorGUID { get; set; }
 
-        public bool CanColonialOutpost;
+        public bool CanColonialOutpost { get; set; }
 
-        public bool CanCylonOutpost;
+        public bool CanCylonOutpost { get; set; }
 
-        public bool CanColonialJumpBeacon;
+        public bool CanColonialJumpBeacon { get; set; }
 
-        public bool CanCylonJumpBeacon;
+        public bool CanCylonJumpBeacon { get; set; }
 
         public MapStarDesc(uint id, Vector2 position, byte gUIIndex, Faction starFaction, int colonialThreatLevel, int cylonThreatLevel, uint sectorGUID, bool canColonialOutpost, bool canCylonOutpost, bool canColonialJumpBeacon, bool canCylonJumpBeacon)
         {

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/MovingNebulaDesc.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/MovingNebulaDesc.cs
@@ -1,44 +1,41 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
+﻿using System.Drawing;
 using System.Numerics;
-using System.Text;
 
 namespace BSGO_Server
 {
-    class MovingNebulaDesc : IProtocolWrite
+    internal class MovingNebulaDesc : IProtocolWrite
     {
-        public string modelName = "movingnebula";
-        public string matSuffix = "1";
-        public Color color = Color.White;
-        public Vector2 textureOffset = new Vector2(0f, 0f);
-        public Vector2 textureScale = new Vector2(1f, 1f);
-        public Vector3 position;
-        public Quaternion rotation;
-        public Vector3 scale = new Vector3(1f, 1f, 1f);
+        public string ModelName { get; set; } = "movingnebula";
+        public string MatSuffix { get; set; } = "1";
+        public Color Color { get; set; } = Color.White;
+        public Vector2 TextureOffset { get; set; } = new Vector2(0f, 0f);
+        public Vector2 TextureScale { get; set; } = new Vector2(1f, 1f);
+        public Vector3 Position { get; set; }
+        public Quaternion Rotation { get; set; }
+        public Vector3 Scale { get; set; } = new Vector3(1f, 1f, 1f);
 
         public MovingNebulaDesc(string modelName, string matSuffix, Color color, Vector2 textureOffset, Vector2 textureScale, Vector3 position, Quaternion rotation, Vector3 scale)
         {
-            this.modelName = modelName;
-            this.matSuffix = matSuffix;
-            this.color = color;
-            this.textureOffset = textureOffset;
-            this.textureScale = textureScale;
-            this.position = position;
-            this.rotation = rotation;
-            this.scale = scale;
+            ModelName = modelName;
+            MatSuffix = matSuffix;
+            Color = color;
+            TextureOffset = textureOffset;
+            TextureScale = textureScale;
+            Position = position;
+            Rotation = rotation;
+            Scale = scale;
         }
 
         public void Write(BgoProtocolWriter w)
         {
-            w.Write(matSuffix);
-            w.Write(modelName);
-            w.Write(rotation);
-            w.Write(position);
-            w.Write(scale);
-            w.Write(textureOffset);
-            w.Write(textureScale);
-            w.Write(color);
+            w.Write(MatSuffix);
+            w.Write(ModelName);
+            w.Write(Rotation);
+            w.Write(Position);
+            w.Write(Scale);
+            w.Write(TextureOffset);
+            w.Write(TextureScale);
+            w.Write(Color);
         }
     }
 }

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/ObjectStats.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/ObjectStats.cs
@@ -1,434 +1,118 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace BSGO_Server
 {
-    class ObjectStats : IProtocolWrite
+    internal class ObjectStats : IProtocolWrite
     {
-        public float Accuracy
-        {
-            get
-            {
-                return ObjStats[ObjectStat.Accuracy];
-            }
-        }
+        public float Accuracy => ObjStats[ObjectStat.Accuracy];
 
-        public float MaxHullPoints
-        {
-            get
-            {
-                return ObjStats[ObjectStat.MaxHullPoints];
-            }
-        }
+        public float MaxHullPoints => ObjStats[ObjectStat.MaxHullPoints];
 
-        public float MaxPowerPoints
-        {
-            get
-            {
-                return ObjStats[ObjectStat.MaxPowerPoints];
-            }
-        }
+        public float MaxPowerPoints => ObjStats[ObjectStat.MaxPowerPoints];
 
-        public float HullRecovery
-        {
-            get
-            {
-                return ObjStats[ObjectStat.HullRecovery];
-            }
-        }
+        public float HullRecovery => ObjStats[ObjectStat.HullRecovery];
 
-        public float PowerRecovery
-        {
-            get
-            {
-                return ObjStats[ObjectStat.PowerRecovery];
-            }
-        }
+        public float PowerRecovery => ObjStats[ObjectStat.PowerRecovery];
 
-        public float Avoidance
-        {
-            get
-            {
-                return ObjStats[ObjectStat.Avoidance];
-            }
-        }
+        public float Avoidance => ObjStats[ObjectStat.Avoidance];
 
-        public float FirewallRating
-        {
-            get
-            {
-                return ObjStats[ObjectStat.FirewallRating];
-            }
-        }
+        public float FirewallRating => ObjStats[ObjectStat.FirewallRating];
 
-        public float ArmorValue
-        {
-            get
-            {
-                return ObjStats[ObjectStat.ArmorValue];
-            }
-        }
+        public float ArmorValue => ObjStats[ObjectStat.ArmorValue];
 
-        public float CriticalDefense
-        {
-            get
-            {
-                return ObjStats[ObjectStat.CriticalDefense];
-            }
-        }
+        public float CriticalDefense => ObjStats[ObjectStat.CriticalDefense];
 
-        public float DamageHigh
-        {
-            get
-            {
-                return ObjStats[ObjectStat.DamageHigh];
-            }
-        }
+        public float DamageHigh => ObjStats[ObjectStat.DamageHigh];
 
-        public float DamageLow
-        {
-            get
-            {
-                return ObjStats[ObjectStat.DamageLow];
-            }
-        }
+        public float DamageLow => ObjStats[ObjectStat.DamageLow];
 
-        public float DrainHigh
-        {
-            get
-            {
-                return ObjStats[ObjectStat.DrainHigh];
-            }
-        }
+        public float DrainHigh => ObjStats[ObjectStat.DrainHigh];
 
-        public float DrainLow
-        {
-            get
-            {
-                return ObjStats[ObjectStat.DrainLow];
-            }
-        }
+        public float DrainLow => ObjStats[ObjectStat.DrainLow];
 
-        public float DPS
-        {
-            get
-            {
-                return (DamageHigh + DamageLow) / 2f / Cooldown;
-            }
-        }
+        public float DPS => (DamageHigh + DamageLow) / 2f / Cooldown;
 
-        public float PenetrationStrength
-        {
-            get
-            {
-                return ObjStats[ObjectStat.PenetrationStrength];
-            }
-        }
+        public float PenetrationStrength => ObjStats[ObjectStat.PenetrationStrength];
 
-        public float ArmorPiercing
-        {
-            get
-            {
-                return ObjStats[ObjectStat.ArmorPiercing];
-            }
-        }
+        public float ArmorPiercing => ObjStats[ObjectStat.ArmorPiercing];
 
-        public float CriticalOffense
-        {
-            get
-            {
-                return ObjStats[ObjectStat.CriticalOffense];
-            }
-        }
+        public float CriticalOffense => ObjStats[ObjectStat.CriticalOffense];
 
-        public float Acceleration
-        {
-            get
-            {
-                return ObjStats[ObjectStat.Acceleration];
-            }
-        }
+        public float Acceleration => ObjStats[ObjectStat.Acceleration];
 
-        public float MaxSpeed
-        {
-            get
-            {
-                return ObjStats[ObjectStat.Speed];
-            }
-        }
+        public float MaxSpeed => ObjStats[ObjectStat.Speed];
 
-        public float BoostSpeed
-        {
-            get
-            {
-                return ObjStats[ObjectStat.BoostSpeed];
-            }
-        }
+        public float BoostSpeed => ObjStats[ObjectStat.BoostSpeed];
 
-        public float BoostCost
-        {
-            get
-            {
-                return ObjStats[ObjectStat.BoostCost];
-            }
-        }
+        public float BoostCost => ObjStats[ObjectStat.BoostCost];
 
-        public float TurnAcceleration
-        {
-            get
-            {
-                return (ObjStats[ObjectStat.PitchAcceleration] + ObjStats[ObjectStat.YawAcceleration]) / 2f;
-            }
-        }
+        public float TurnAcceleration => (ObjStats[ObjectStat.PitchAcceleration] + ObjStats[ObjectStat.YawAcceleration]) / 2f;
 
-        public float TurnSpeed
-        {
-            get
-            {
-                return (ObjStats[ObjectStat.PitchMaxSpeed] + ObjStats[ObjectStat.YawMaxSpeed]) / 2f;
-            }
-        }
+        public float TurnSpeed => (ObjStats[ObjectStat.PitchMaxSpeed] + ObjStats[ObjectStat.YawMaxSpeed]) / 2f;
 
-        public float PitchMaxSpeed
-        {
-            get
-            {
-                return ObjStats[ObjectStat.PitchMaxSpeed];
-            }
-        }
+        public float PitchMaxSpeed => ObjStats[ObjectStat.PitchMaxSpeed];
 
-        public float YawMaxSpeed
-        {
-            get
-            {
-                return ObjStats[ObjectStat.YawMaxSpeed];
-            }
-        }
+        public float YawMaxSpeed => ObjStats[ObjectStat.YawMaxSpeed];
 
-        public float RollMaxSpeed
-        {
-            get
-            {
-                return ObjStats[ObjectStat.RollMaxSpeed];
-            }
-        }
+        public float RollMaxSpeed => ObjStats[ObjectStat.RollMaxSpeed];
 
-        public float StrafeMaxSpeed
-        {
-            get
-            {
-                return ObjStats[ObjectStat.StrafeMaxSpeed];
-            }
-        }
+        public float StrafeMaxSpeed => ObjStats[ObjectStat.StrafeMaxSpeed];
 
-        public float PitchAcceleration
-        {
-            get
-            {
-                return ObjStats[ObjectStat.PitchAcceleration];
-            }
-        }
+        public float PitchAcceleration => ObjStats[ObjectStat.PitchAcceleration];
 
-        public float YawAcceleration
-        {
-            get
-            {
-                return ObjStats[ObjectStat.YawAcceleration];
-            }
-        }
+        public float YawAcceleration => ObjStats[ObjectStat.YawAcceleration];
 
-        public float RollAcceleration
-        {
-            get
-            {
-                return ObjStats[ObjectStat.RollAcceleration];
-            }
-        }
+        public float RollAcceleration => ObjStats[ObjectStat.RollAcceleration];
 
-        public float StrafeAcceleration
-        {
-            get
-            {
-                return ObjStats[ObjectStat.StrafeAcceleration];
-            }
-        }
+        public float StrafeAcceleration => ObjStats[ObjectStat.StrafeAcceleration];
 
-        public float InertiaCompensation
-        {
-            get
-            {
-                return ObjStats[ObjectStat.InertiaCompensation];
-            }
-        }
+        public float InertiaCompensation => ObjStats[ObjectStat.InertiaCompensation];
 
-        public float LifeTime
-        {
-            get
-            {
-                return ObjStats[ObjectStat.LifeTime];
-            }
-        }
+        public float LifeTime => ObjStats[ObjectStat.LifeTime];
 
-        public int MaxCargo
-        {
-            get
-            {
-                return (int)ObjStats[ObjectStat.CargoHoldVolume];
-            }
-        }
+        public int MaxCargo => (int)ObjStats[ObjectStat.CargoHoldVolume];
 
-        public float FTLRange
-        {
-            get
-            {
-                return ObjStats[ObjectStat.FtlRange];
-            }
-        }
+        public float FTLRange => ObjStats[ObjectStat.FtlRange];
 
-        public float FTLCharge
-        {
-            get
-            {
-                return ObjStats[ObjectStat.FtlCharge];
-            }
-        }
+        public float FTLCharge => ObjStats[ObjectStat.FtlCharge];
 
-        public float FTLCooldown
-        {
-            get
-            {
-                return ObjStats[ObjectStat.FtlCooldown];
-            }
-        }
+        public float FTLCooldown => ObjStats[ObjectStat.FtlCooldown];
 
-        public float FTLCost
-        {
-            get
-            {
-                return ObjStats[ObjectStat.FtlCost];
-            }
-        }
+        public float FTLCost => ObjStats[ObjectStat.FtlCost];
 
-        public float OptimalRange
-        {
-            get
-            {
-                return ObjStats[ObjectStat.OptimalRange];
-            }
-        }
+        public float OptimalRange => ObjStats[ObjectStat.OptimalRange];
 
-        public float MaxRange
-        {
-            get
-            {
-                return ObjStats[ObjectStat.MaxRange];
-            }
-        }
+        public float MaxRange => ObjStats[ObjectStat.MaxRange];
 
-        public float MinRange
-        {
-            get
-            {
-                return ObjStats[ObjectStat.MinRange];
-            }
-        }
+        public float MinRange => ObjStats[ObjectStat.MinRange];
 
-        public float Angle
-        {
-            get
-            {
-                return ObjStats[ObjectStat.Angle];
-            }
-        }
+        public float Angle => ObjStats[ObjectStat.Angle];
 
-        public float Cooldown
-        {
-            get
-            {
-                return ObjStats[ObjectStat.Cooldown];
-            }
-        }
+        public float Cooldown => ObjStats[ObjectStat.Cooldown];
 
-        public float DamageMining
-        {
-            get
-            {
-                return ObjStats[ObjectStat.DamageMining];
-            }
-        }
+        public float DamageMining => ObjStats[ObjectStat.DamageMining];
 
-        public float PowerPointCost
-        {
-            get
-            {
-                return ObjStats[ObjectStat.PowerPointCost];
-            }
-        }
+        public float PowerPointCost => ObjStats[ObjectStat.PowerPointCost];
 
-        public float PowerPointCostPerSecond
-        {
-            get
-            {
-                return ObjStats[ObjectStat.PpCostPerSec];
-            }
-        }
+        public float PowerPointCostPerSecond => ObjStats[ObjectStat.PpCostPerSec];
 
-        public float FlareRange
-        {
-            get
-            {
-                return ObjStats[ObjectStat.FlareRange];
-            }
-        }
+        public float FlareRange => ObjStats[ObjectStat.FlareRange];
 
-        public float HullPointRestore
-        {
-            get
-            {
-                return ObjStats[ObjectStat.HullPointRestore];
-            }
-        }
+        public float HullPointRestore => ObjStats[ObjectStat.HullPointRestore];
 
-        public float PowerPointRestore
-        {
-            get
-            {
-                return ObjStats[ObjectStat.PowerPointRestore];
-            }
-        }
+        public float PowerPointRestore => ObjStats[ObjectStat.PowerPointRestore];
 
-        public float DetectionInnerRadius
-        {
-            get
-            {
-                return ObjStats[ObjectStat.DetectionInnerRadius];
-            }
-        }
+        public float DetectionInnerRadius => ObjStats[ObjectStat.DetectionInnerRadius];
 
-        public float DetectionOuterRadius
-        {
-            get
-            {
-                return ObjStats[ObjectStat.DetectionOuterRadius];
-            }
-        }
+        public float DetectionOuterRadius => ObjStats[ObjectStat.DetectionOuterRadius];
 
-        public float DetectionVisualRadius
-        {
-            get
-            {
-                return ObjStats[ObjectStat.DetectionVisualRadius];
-            }
-        }
+        public float DetectionVisualRadius => ObjStats[ObjectStat.DetectionVisualRadius];
 
         public Dictionary<ObjectStat, float> ObjStats;
 
-        public ObjectStats(Dictionary<ObjectStat, float> objStats)
-        {
+        public ObjectStats(Dictionary<ObjectStat, float> objStats) =>
             ObjStats = objStats;
-        }
-
+        
         public void Write(BgoProtocolWriter w)
         {
             int num = ObjStats.Count;

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/Price.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/Price.cs
@@ -1,27 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace BSGO_Server
 {
-    class Price : IProtocolWrite
+    internal class Price : IProtocolWrite
     {
-        public Dictionary<ShipConsumableCard, float> items = new Dictionary<ShipConsumableCard, float>();
+        public Dictionary<ShipConsumableCard, float> Items { get; set; } = new Dictionary<ShipConsumableCard, float>();
 
         public Price()
         {
-
         }
 
         public Price(Dictionary<ShipConsumableCard, float> items)
         {
-            this.items = items;
+            Items = items;
         }
 
         public void Write(BgoProtocolWriter w)
         {
-            w.Write(items.Count);
-            foreach(KeyValuePair<ShipConsumableCard, float> item in items)
+            w.Write(Items.Count);
+            foreach(KeyValuePair<ShipConsumableCard, float> item in Items)
             {
                 w.Write(item.Key.CardGUID);
                 w.Write(item.Value);

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/ShipImmutableSlot.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/ShipImmutableSlot.cs
@@ -1,22 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class ShipImmutableSlot : IProtocolWrite
+    internal class ShipImmutableSlot : IProtocolWrite
     {
-        public ushort SlotId;
+        public ushort SlotId { get; set; }
 
-        public ShipSlotType SystemType;
+        public ShipSlotType SystemType { get; set; }
 
-        public ushort ObjectPointServerHash;
+        public ushort ObjectPointServerHash { get; set; }
 
-        public uint SystemKey;
+        public uint SystemKey { get; set; }
 
-        public uint SystemLevel;
+        public uint SystemLevel { get; set; }
 
-        public uint ConsumableKey;
+        public uint ConsumableKey { get; set; }
 
         public void Write(BgoProtocolWriter w)
         {

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/ShipSlotCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/ShipSlotCard.cs
@@ -1,16 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class ShipSlotCard : IProtocolWrite
+    internal class ShipSlotCard : IProtocolWrite
     {
-        public byte Level;
-        public ushort SlotId;
-        public ShipSlotType SystemType;
-        public string ObjectPoint;
-        public ushort ObjectPointServerHash;
+        public byte Level { get; set; }
+        public ushort SlotId { get; set; }
+        public ShipSlotType SystemType { get; set; }
+        public string ObjectPoint { get; set; }
+        public ushort ObjectPointServerHash { get; set; }
 
         public ShipSlotCard(byte level, ushort slotId, ShipSlotType systemType, string objectPoint, ushort objectPointServerHash)
         {

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/SpotDesc.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/SpotDesc.cs
@@ -1,21 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Numerics;
-using System.Text;
+﻿using System.Numerics;
 
 namespace BSGO_Server
 {
-    class SpotDesc : IProtocolWrite
+    internal class SpotDesc : IProtocolWrite
     {
-        public ushort ObjectPointServerHash;
+        public ushort ObjectPointServerHash { get; set; }
 
-        public string ObjectPointName;
+        public string ObjectPointName { get; set; }
 
-        public SpotType Type;
+        public SpotType Type { get; set; }
 
-        public Vector3 LocalPosition;
+        public Vector3 LocalPosition { get; set; }
 
-        public Quaternion LocalRotation;
+        public Quaternion LocalRotation { get; set; }
 
         public SpotDesc(ushort objectPointServerHash, string objectPointName, SpotType type, Vector3 localPosition, Quaternion localRotation)
         {

--- a/BSGO Server/BSGO Server/Server/Catalogue/Others/SunDesc.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/Others/SunDesc.cs
@@ -1,44 +1,41 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
+﻿using System.Drawing;
 using System.Numerics;
-using System.Text;
 
 namespace BSGO_Server
 {
-    class SunDesc : IProtocolWrite
+    internal class SunDesc : IProtocolWrite
     {
-        public Color raysColor = Color.White;
-        public Color streakColor = Color.White;
-        public Color glowColor = Color.Red;
-        public Color discColor = Color.White;
-        public bool occlusionFade = true;
-        public Vector3 position;
-        public Quaternion rotation;
-        public Vector3 scale = new Vector3(1f, 1f, 1f);
+        public Color RaysColor { get; set; } = Color.White;
+        public Color StreakColor { get; set; } = Color.White;
+        public Color GlowColor { get; set; } = Color.Red;
+        public Color DiscColor { get; set; } = Color.White;
+        public bool OcclusionFade { get; set; } = true;
+        public Vector3 Position { get; set; }
+        public Quaternion Rotation { get; set; }
+        public Vector3 Scale { get; set; } = new Vector3(1f, 1f, 1f);
 
         public SunDesc(Color raysColor, Color streakColor, Color glowColor, Color discColor, bool occlusionFade, Vector3 position, Quaternion rotation, Vector3 scale)
         {
-            this.raysColor = raysColor;
-            this.streakColor = streakColor;
-            this.glowColor = glowColor;
-            this.discColor = discColor;
-            this.occlusionFade = occlusionFade;
-            this.position = position;
-            this.rotation = rotation;
-            this.scale = scale;
+            RaysColor = raysColor;
+            StreakColor = streakColor;
+            GlowColor = glowColor;
+            DiscColor = discColor;
+            OcclusionFade = occlusionFade;
+            Position = position;
+            Rotation = rotation;
+            Scale = scale;
         }
 
         public void Write(BgoProtocolWriter w)
         {
-            w.Write(raysColor);
-            w.Write(streakColor);
-            w.Write(glowColor);
-            w.Write(discColor);
-            w.Write(occlusionFade);
-            w.Write(rotation);
-            w.Write(position);
-            w.Write(scale);
+            w.Write(RaysColor);
+            w.Write(StreakColor);
+            w.Write(GlowColor);
+            w.Write(DiscColor);
+            w.Write(OcclusionFade);
+            w.Write(Rotation);
+            w.Write(Position);
+            w.Write(Scale);
         }
     }
 }

--- a/BSGO Server/BSGO Server/Server/Catalogue/OwnerCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/OwnerCard.cs
@@ -1,19 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class OwnerCard : Card
+    internal class OwnerCard : Card
     {
-        public bool IsDockable;
+        public bool IsDockable { get; set; }
 
-        public float DockRange;
+        public float DockRange { get; set; }
 
-        public byte Level;
+        public byte Level { get; set; }
 
         public OwnerCard(uint cardGUID, CardView cardView, bool isDockable, float dockRange, byte level)
-    : base(cardGUID, cardView)
+            : base(cardGUID, cardView)
         {
             IsDockable = isDockable;
             DockRange = dockRange;

--- a/BSGO Server/BSGO Server/Server/Catalogue/RegulationCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/RegulationCard.cs
@@ -27,7 +27,7 @@ namespace BSGO_Server
             base.Write(w);
             w.Write((byte)TargetBracketMode);
             w.Write(SectorMapEnabled);
-            ushort num = (ushort)AbilityTargetRelations.Count;
+            //ushort num = (ushort)AbilityTargetRelations.Count;
             foreach (KeyValuePair<uint, HashSet<ShipAbilitySide>> pair in AbilityTargetRelations)
             {
                 w.Write(pair.Key);

--- a/BSGO Server/BSGO Server/Server/Catalogue/RegulationCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/RegulationCard.cs
@@ -1,21 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace BSGO_Server
 {
-    class RegulationCard : Card
+    internal class RegulationCard : Card
     {
-        public ConsumableEffectType[] effectTypeBlacklist;
-        public Dictionary<uint, HashSet<ShipAbilitySide>> AbilityTargetRelations;
-        public Dictionary<uint, HashSet<ShipAbilityTarget>> AbilityTargetTypes;
-        public TargetBracketMode TargetBracketMode;
-        public bool SectorMapEnabled;
+        public ConsumableEffectType[] EffectTypeBlacklist { get; set; }
+        public Dictionary<uint, HashSet<ShipAbilitySide>> AbilityTargetRelations { get; set; }
+        public Dictionary<uint, HashSet<ShipAbilityTarget>> AbilityTargetTypes { get; set; }
+        public TargetBracketMode TargetBracketMode { get; set; }
+        public bool SectorMapEnabled { get; set; }
 
         public RegulationCard(uint cardGUID, CardView cardView, ConsumableEffectType[] effectTypeBlacklist, Dictionary<uint, HashSet<ShipAbilitySide>> abilityTargetRelations, Dictionary<uint, HashSet<ShipAbilityTarget>> abilityTargetTypes, TargetBracketMode targetBracketMode, bool sectorMapEnabled)
             : base(cardGUID, cardView)
         {
-            this.effectTypeBlacklist = effectTypeBlacklist;
+            this.EffectTypeBlacklist = effectTypeBlacklist;
             AbilityTargetRelations = abilityTargetRelations;
             AbilityTargetTypes = abilityTargetTypes;
             TargetBracketMode = targetBracketMode;
@@ -45,11 +43,11 @@ namespace BSGO_Server
                 }
             }
 
-            int num2 = effectTypeBlacklist.Length;
+            int num2 = EffectTypeBlacklist.Length;
             w.Write(num2);
             for (int j = 0; j < num2; j++)
             {
-                w.Write((byte)effectTypeBlacklist[j]);
+                w.Write((byte)EffectTypeBlacklist[j]);
             }
         }
     }

--- a/BSGO Server/BSGO Server/Server/Catalogue/RewardCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/RewardCard.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class RewardCard : Card
+    internal class RewardCard : Card
     {
-        public int Experience;
-        //public List<ShipItem> Items = new List<ShipItems>();
-        public AugmentActionType Action;
-        public string Package = string.Empty;
-        public uint ItemGroup = 101;
-        public uint PackagedCubits;
+        public int Experience { get; set; }
+        //public List<ShipItem> Items { get; set; }= new List<ShipItems>();
+        public AugmentActionType Action { get; set; }
+        public string Package { get; set; } = string.Empty;
+        public uint ItemGroup { get; set; } = 101;
+        public uint PackagedCubits { get; set; }
 
         public RewardCard(uint cardGUID, CardView cardView, int experience, AugmentActionType action, string package, uint packagedCubits)
             : base(cardGUID, cardView)

--- a/BSGO Server/BSGO Server/Server/Catalogue/SectorCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/SectorCard.cs
@@ -1,31 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Text;
+﻿using System.Drawing;
 
 namespace BSGO_Server
 {
-    class SectorCard : Card
+    internal class SectorCard : Card
     {
-        public float Width;
-        public float Height;
-        public float Length;
-        public uint RegulationCardGUID;
-        public Color AmbientColor;
-        public Color FogColor;
-        public int FogDensity;
-        public Color DustColor;
-        public int DustDensity;
-        public BackgroundDesc NebulaDesc;
-        public BackgroundDesc StarsDesc;
-        public BackgroundDesc StarsMultDesc;
-        public BackgroundDesc StarsVarianceDesc;
-        public MovingNebulaDesc[] MovingNebulaDescs;
-        public LightDesc[] LightDescs;
-        public SunDesc[] SunDescs;
-        public JGlobalFog GlobalFogDesc;
-        public JCameraFx CameraFxDesc;
-        public string[] RequiredAssets;
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public float Length { get; set; }
+        public uint RegulationCardGUID { get; set; }
+        public Color AmbientColor { get; set; }
+        public Color FogColor { get; set; }
+        public int FogDensity { get; set; }
+        public Color DustColor { get; set; }
+        public int DustDensity { get; set; }
+        public BackgroundDesc NebulaDesc { get; set; }
+        public BackgroundDesc StarsDesc { get; set; }
+        public BackgroundDesc StarsMultDesc { get; set; }
+        public BackgroundDesc StarsVarianceDesc { get; set; }
+        public MovingNebulaDesc[] MovingNebulaDescs { get; set; }
+        public LightDesc[] LightDescs { get; set; }
+        public SunDesc[] SunDescs { get; set; }
+        public JGlobalFog GlobalFogDesc { get; set; }
+        public JCameraFx CameraFxDesc { get; set; }
+        public string[] RequiredAssets { get; set; }
 
         public SectorCard(uint cardGUID, CardView cardView, float width, float height, float length, uint regulationCardGUID, Color ambientColor, Color fogColor, int fogDensity, Color dustColor, int dustDensity, BackgroundDesc nebulaDesc, BackgroundDesc starsDesc, BackgroundDesc starsMultDesc, BackgroundDesc starsVarianceDesc, MovingNebulaDesc[] movingNebulaDescs, LightDesc[] lightDescs, SunDesc[] sunDescs, JGlobalFog globalFogDesc, JCameraFx cameraFxDesc, string[] requiredAssets)
             : base(cardGUID, cardView)
@@ -70,21 +67,18 @@ namespace BSGO_Server
             int num = MovingNebulaDescs.Length;
             w.Write((ushort)num);
             for(int i = 0; i < num; i++)
-            {
                 MovingNebulaDescs[i].Write(w);
-            }
+            
             int num2 = LightDescs.Length;
             w.Write((ushort)num2);
             for (int j = 0; j < num2; j++)
-            {
                 LightDescs[j].Write(w);
-            }
+            
             int num3 = SunDescs.Length;
             w.Write((ushort)num3);
             for (int k = 0; k < num3; k++)
-            {
                 SunDescs[k].Write(w);
-            }
+            
             GlobalFogDesc.Write(w);
             CameraFxDesc.Write(w);
             w.Write(RequiredAssets);

--- a/BSGO Server/BSGO Server/Server/Catalogue/ShipCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/ShipCard.cs
@@ -1,29 +1,27 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace BSGO_Server
 {
-    class ShipCard : Card
+    internal class ShipCard : Card
     {
-        public uint ShipObjectKey;
-        public byte Level;
-        public byte MaxLevel;
-        public byte LevelRequeriment;
-        public byte HangarID;
-        public uint next; // it's called num on the code and fetches other shipcard if not equals 0
-        public float Durability;
-        public byte Tier;
-        public ShipRole[] ShipRoles;
-        public ShipRoleDeprecated ShipRoleDeprecated;
-        public string PaperdollUiLayoutfile;
-        public List<ShipSlotCard> Slots;
-        public bool CubitOnlyRepair;
-        public List<uint> VariantHangarIDs;
-        public int ParentHangerID;
-        public ObjectStats Stats;
-        public Faction Faction;
-        public List<ShipImmutableSlot> ImmutableSlots;
+        public uint ShipObjectKey { get; set; }
+        public byte Level { get; set; }
+        public byte MaxLevel { get; set; }
+        public byte LevelRequeriment { get; set; }
+        public byte HangarID { get; set; }
+        public uint Next { get; set; } // it's called num on the code and fetches other shipcard if not equals 0
+        public float Durability { get; set; }
+        public byte Tier { get; set; }
+        public ShipRole[] ShipRoles { get; set; }
+        public ShipRoleDeprecated ShipRoleDeprecated { get; set; }
+        public string PaperdollUiLayoutfile { get; set; }
+        public List<ShipSlotCard> Slots { get; set; }
+        public bool CubitOnlyRepair { get; set; }
+        public List<uint> VariantHangarIDs { get; set; }
+        public int ParentHangerID { get; set; }
+        public ObjectStats Stats { get; set; }
+        public Faction Faction { get; set; }
+        public List<ShipImmutableSlot> ImmutableSlots { get; set; }
 
         public ShipCard(uint cardGUID, CardView cardView, uint shipObjectKey, byte level, byte maxLevel, byte levelRequeriment, byte hangarID, uint next, float durability, byte tier, ShipRole[] shipRoles, ShipRoleDeprecated shipRoleDeprecated, string paperdollUiLayoutfile, List<ShipSlotCard> slots, bool cubitOnlyRepair, List<uint> variantHangarIDs, int parentHangerID, ObjectStats stats, Faction faction, List<ShipImmutableSlot> immutableSlots)
             : base(cardGUID, cardView)
@@ -33,7 +31,7 @@ namespace BSGO_Server
             MaxLevel = maxLevel;
             LevelRequeriment = levelRequeriment;
             HangarID = hangarID;
-            this.next = next;
+            this.Next = next;
             Durability = durability;
             Tier = tier;
             ShipRoles = shipRoles;
@@ -56,30 +54,27 @@ namespace BSGO_Server
             w.Write(MaxLevel);
             w.Write(LevelRequeriment);
             w.Write(HangarID);
-            w.Write(next);
+            w.Write(Next);
             w.Write(Durability);
             w.Write(Tier);
             int num = ShipRoles.Length;
             w.Write((ushort)num);
             for(int i = 0; i < num; i++)
-            {
                 w.Write((byte)ShipRoles[i]);
-            }
+            
             w.Write((byte)ShipRoleDeprecated);
             w.Write(PaperdollUiLayoutfile);
             int num2 = Slots.Count;
             w.Write((ushort)num2);
             for(int j= 0; j < num2; j++)
-            {
                 Slots[j].Write(w);
-            }
+            
             w.Write(CubitOnlyRepair);
             int num3 = VariantHangarIDs.Count;
             w.Write((ushort)num3);
             for (int k = 0; k < num3; k++)
-            {
                 w.Write(VariantHangarIDs[k]);
-            }
+            
             w.Write(ParentHangerID);
             Stats.Write(w);
             w.Write((byte)Faction);

--- a/BSGO Server/BSGO Server/Server/Catalogue/ShipConsumableCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/ShipConsumableCard.cs
@@ -1,35 +1,31 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class ShipConsumableCard : Card
+    internal class ShipConsumableCard : Card
     {
-        public ushort ConsumableType;
+        public ushort ConsumableType { get; set; }
 
-        public ObjectStats ItemBuffMultiply;
+        public ObjectStats ItemBuffMultiply { get; set; }
 
-        public ObjectStats ItemBuffAdd;
+        public ObjectStats ItemBuffAdd { get; set; }
 
-        public byte Tier;
+        public byte Tier { get; set; }
 
-        public AugmentActionType Action;
+        public AugmentActionType Action { get; set; }
 
-        public bool IsAugment;
+        public bool IsAugment { get; set; }
 
-        public bool AutoConsume;
+        public bool AutoConsume { get; set; }
 
-        public bool Trashable;
+        public bool Trashable { get; set; }
 
-        public uint buyCount;
+        public uint BuyCount { get; set; }
 
-        public ConsumableAttribute[] sortingAttributes;
+        public ConsumableAttribute[] SortingAttributes { get; set; }
 
-        public ConsumableEffectType effectType;
+        public ConsumableEffectType EffectType { get; set; }
 
         public ShipConsumableCard(uint cardGUID, CardView cardView, ushort consumableType, ObjectStats itemBuffMultiply, ObjectStats itemBuffAdd, byte tier, AugmentActionType action, bool isAugment, bool autoConsume, bool trashable, uint buyCount, ConsumableAttribute[] sortingAttributes, ConsumableEffectType effectType)
-    : base(cardGUID, cardView)
+            : base(cardGUID, cardView)
         {
             ConsumableType = consumableType;
             ItemBuffMultiply = itemBuffMultiply;
@@ -39,9 +35,9 @@ namespace BSGO_Server
             IsAugment = isAugment;
             AutoConsume = autoConsume;
             Trashable = trashable;
-            this.buyCount = buyCount;
-            this.sortingAttributes = sortingAttributes;
-            this.effectType = effectType;
+            BuyCount = buyCount;
+            SortingAttributes = sortingAttributes;
+            EffectType = effectType;
         }
 
         public override void Write(BgoProtocolWriter w)
@@ -55,13 +51,12 @@ namespace BSGO_Server
             w.Write(IsAugment);
             w.Write(AutoConsume);
             w.Write(Trashable);
-            w.Write(buyCount);
-            w.Write(sortingAttributes.Length);
-            foreach(ConsumableAttribute atr in sortingAttributes)
-            {
+            w.Write(BuyCount);
+            w.Write(SortingAttributes.Length);
+            foreach(ConsumableAttribute atr in SortingAttributes)
                 w.Write(atr.Attribute);
-            }
-            w.Write((byte)effectType);
+            
+            w.Write((byte)EffectType);
         }
     }
 }

--- a/BSGO Server/BSGO Server/Server/Catalogue/ShipLightCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/ShipLightCard.cs
@@ -1,18 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class ShipLightCard : Card
+    internal class ShipLightCard : Card
     {
-        public uint ShipObjectKey;
+        public uint ShipObjectKey { get; set; }
 
-        public byte Tier;
+        public byte Tier { get; set; }
 
-        public ShipRole[] ShipRoles;
+        public ShipRole[] ShipRoles { get; set; }
 
-        public ShipRoleDeprecated ShipRoleDeprecated;
+        public ShipRoleDeprecated ShipRoleDeprecated { get; set; }
 
         public ShipLightCard(uint cardGUID, CardView cardView, uint shipObjectKey, byte tier, ShipRole[] shipRoles, ShipRoleDeprecated shipRoleDeprecated)
             : base(cardGUID, cardView)
@@ -31,9 +27,8 @@ namespace BSGO_Server
             int num = ShipRoles.Length;
             w.Write((ushort)num);
             for (int i = 0; i < num; i++)
-            {
                 w.Write((byte)ShipRoles[i]);
-            }
+            
             w.Write((byte)ShipRoleDeprecated);
         }
     }

--- a/BSGO Server/BSGO Server/Server/Catalogue/ShipListCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/ShipListCard.cs
@@ -1,16 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace BSGO_Server
 {
-    class ShipListCard : Card
+    internal class ShipListCard : Card
     {
-        public List<ShipCard> ShipCards;
+        public List<ShipCard> ShipCards { get; set; }
 
-        public List<ShipCard> UpgradeShipCards;
+        public List<ShipCard> UpgradeShipCards { get; set; }
 
-        public List<ShipCard> VariantShipCards;
+        public List<ShipCard> VariantShipCards { get; set; }
 
         public ShipListCard(uint cardGUID) : base(cardGUID, CardView.ShipList)
         {

--- a/BSGO Server/BSGO Server/Server/Catalogue/ShopItemCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/ShopItemCard.cs
@@ -1,33 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class ShopItemCard : Card
+    internal class ShopItemCard : Card
     {
-        public ShopCategory Category;
+        public ShopCategory Category { get; set; }
 
-        public ShopItemType ItemType;
+        public ShopItemType ItemType { get; set; }
 
-        public byte Tier;
+        public byte Tier { get; set; }
 
-        public string[] SortingNames;
+        public string[] SortingNames { get; set; }
 
-        public int SortingWeight;
+        public int SortingWeight { get; set; }
 
-        public Price BuyPrice = new Price();
+        public Price BuyPrice { get; set; } = new Price();
 
-        public Price UpgradePrice = new Price();
+        public Price UpgradePrice { get; set; } = new Price();
 
-        public Price SellPrice = new Price();
+        public Price SellPrice { get; set; } = new Price();
 
-        public Faction Faction;
+        public Faction Faction { get; set; }
 
-        public bool CanBeSold;
+        public bool CanBeSold { get; set; }
 
         public ShopItemCard(uint cardGUID, CardView cardView, ShopCategory category, ShopItemType itemType, byte tier, string[] sortingNames, int sortingWeight, Price buyPrice, Price upgradePrice, Price sellPrice, Faction faction, bool canBeSold)
-    : base(cardGUID, cardView)
+            : base(cardGUID, cardView)
         {
             Category = category;
             ItemType = itemType;

--- a/BSGO Server/BSGO Server/Server/Catalogue/StickerListCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/StickerListCard.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class StickerListCard : Card
+    internal class StickerListCard : Card
     {
         public StickerListCard(uint cardGUID, CardView cardView)
             : base(cardGUID, cardView)

--- a/BSGO Server/BSGO Server/Server/Catalogue/WorldCard.cs
+++ b/BSGO Server/BSGO Server/Server/Catalogue/WorldCard.cs
@@ -1,21 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class WorldCard : Card
+    internal class WorldCard : Card
     {
-        public string PrefabName;
-        public int LODCount;
-        public float Radius;
-        public SpotDesc[] Spots;
-        public string SystemMapTexture;
-        public sbyte FrameIndex = -1;
-        public sbyte SecondaryFrameIndex;
-        public bool Targetable = true;
-        public bool ShowBracketWhenInRange = true;
-        public bool ForceShowOnMap;
+        public string PrefabName { get; set; }
+        public int LODCount { get; set; }
+        public float Radius { get; set; }
+        public SpotDesc[] Spots { get; set; }
+        public string SystemMapTexture { get; set; }
+        public sbyte FrameIndex { get; set; } = -1;
+        public sbyte SecondaryFrameIndex { get; set; }
+        public bool Targetable { get; set; } = true;
+        public bool ShowBracketWhenInRange { get; set; } = true;
+        public bool ForceShowOnMap { get; set; }
 
         public WorldCard(uint cardGUID, CardView cardView, string prefabName, int lODCount, float radius, SpotDesc[] spots, string systemMapTexture, sbyte frameIndex, sbyte secondaryFrameIndex, bool targetable, bool showBracketWhenInRange, bool forceShowOnMap)
             : base(cardGUID, cardView)
@@ -40,9 +36,8 @@ namespace BSGO_Server
             w.Write(Radius);
             w.Write((ushort)Spots.Length);
             foreach(SpotDesc spot in Spots)
-            {
                 spot.Write(w);
-            }
+            
             w.Write(SystemMapTexture);
             w.Write(FrameIndex);
             w.Write(SecondaryFrameIndex);

--- a/BSGO Server/BSGO Server/Server/Character.cs
+++ b/BSGO Server/BSGO Server/Server/Character.cs
@@ -1,16 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
-using BSGO_Server.Database;
 using BSGO_Server.Database.Entities;
 
 namespace BSGO_Server
 {
-    class Character
+    internal class Character
     {
-        private int index;
-        public string name;
-        public Faction Faction;
+        private readonly int index;
+        public string Name { get; set; }
+        public Faction Faction { get; set; }
 
         public GameLocation GameLocation {
             get
@@ -26,17 +24,17 @@ namespace BSGO_Server
         }
         private GameLocation gameLocation;
         private GameLocation lastGameLocation = GameLocation.Unknown;
-        public Dictionary<AvatarItem, string> items = new Dictionary<AvatarItem, string>();
-        public uint WorldCardGUID = 22131177;
+        public Dictionary<AvatarItem, string> Items { get; set; } = new Dictionary<AvatarItem, string>();
+        public uint WorldCardGUID { get; set; } = 22131177;
 
-        public byte qweasd;
-        public byte shipMode;
-        public float shipSpeed;
+        public byte Qweasd { get; set; }
+        public byte ShipMode { get; set; }
+        public float ShipSpeed { get; set; }
 
         public Character(int index)
         {
             this.index = index;
-            this.gameLocation = GameLocation.Starter;
+            gameLocation = GameLocation.Starter;
 
             GUICard ownerGUIDCard = new GUICard((uint)index, CardView.GUI, "", 0, "", 0, "", "GUI/Slots/" + ((GUICard)Catalogue.FetchCard(WorldCardGUID, CardView.GUI)).Key, "", new string[0]);
             OwnerCard ownerCard = new OwnerCard((uint)index, CardView.Owner, false, 0, 1);
@@ -44,22 +42,21 @@ namespace BSGO_Server
             Catalogue.AddCard(ownerCard);
 
             Characters character = Database.Database.GetCharacterById(Server.GetClientByIndex(index).playerId.ToString());
-            if (character == null)
+            if (character is null)
                 return;
 
-            this.name = character.Name;
-            this.Faction = (Faction)character.Faction;
-            this.gameLocation = (GameLocation)character.GameLocation;
+            Name = character.Name;
+            Faction = (Faction)character.Faction;
+            gameLocation = (GameLocation)character.GameLocation;
 
             foreach (KeyValuePair<string, string> item in character.AvatarItems)
-            {
-                items.Add((AvatarItem)Enum.Parse(typeof(AvatarItem), item.Key), item.Value);
-            }
+                Items.Add((AvatarItem)Enum.Parse(typeof(AvatarItem), item.Key), item.Value);
+            
 
         }
 
         // Returns the Transition Scene Type based on where you are/were.
-        public TransSceneType getTransSceneType()
+        public TransSceneType GetTransSceneType()
         {
             switch (gameLocation)
             {

--- a/BSGO Server/BSGO Server/Server/Character.cs
+++ b/BSGO Server/BSGO Server/Server/Character.cs
@@ -41,7 +41,7 @@ namespace BSGO_Server
             Catalogue.AddCard(ownerGUIDCard);
             Catalogue.AddCard(ownerCard);
 
-            Characters character = Database.Database.GetCharacterById(Server.GetClientByIndex(index).playerId.ToString());
+            Characters character = Database.Database.GetCharacterById(Server.GetClientByIndex(index).PlayerId.ToString());
             if (character is null)
                 return;
 

--- a/BSGO Server/BSGO Server/Server/Client.cs
+++ b/BSGO Server/BSGO Server/Server/Client.cs
@@ -11,8 +11,8 @@ namespace BSGO_Server
         public bool Closing { get; set; } = false;
         private readonly byte[] _buffer = new byte[65535];
 
-        public uint playerId;
-        public Character Character;
+        public uint PlayerId { get; set; }
+        public Character Character { get; set; }
 
         public void StartClient()
         { 
@@ -46,6 +46,7 @@ namespace BSGO_Server
             }
         }
 
+        // Unused param index, wip?
         private void CloseClient(int index)
         {
             Log.Add(LogSeverity.INFO, string.Format("Connection from {0} has been terminated.", Ip));

--- a/BSGO Server/BSGO Server/Server/Client.cs
+++ b/BSGO Server/BSGO Server/Server/Client.cs
@@ -1,25 +1,23 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Net.Sockets;
-using System.Text;
 
 namespace BSGO_Server
 {
-    class Client
+    internal class Client
     {
-        public int index;
-        public string ip;
-        public Socket socket;
-        public bool closing = false;
-        private byte[] _buffer = new byte[65535];
+        public int Index { get; set; }
+        public string Ip { get; set; }
+        public Socket Socket { get; set; }
+        public bool Closing { get; set; } = false;
+        private readonly byte[] _buffer = new byte[65535];
 
         public uint playerId;
         public Character Character;
 
         public void StartClient()
         { 
-            socket.BeginReceive(_buffer, 0, _buffer.Length, SocketFlags.None, new AsyncCallback(ReceiveCallback), socket);
-            closing = false;
+            Socket.BeginReceive(_buffer, 0, _buffer.Length, SocketFlags.None, new AsyncCallback(ReceiveCallback), Socket);
+            Closing = false;
         }
 
         private void ReceiveCallback(IAsyncResult ar)
@@ -31,28 +29,28 @@ namespace BSGO_Server
                 int received = socket.EndReceive(ar);
                 if (received <= 0)
                 {
-                    CloseClient(index);
+                    CloseClient(Index);
                 }
                 else
                 {
                     byte[] databuffer = new byte[received];
                     Array.Copy(_buffer, databuffer, received);
-                    ProtocolManager.HandleNetworkInformation(index, databuffer);
+                    ProtocolManager.HandleNetworkInformation(Index, databuffer);
                     socket.BeginReceive(_buffer, 0, _buffer.Length, SocketFlags.None, new AsyncCallback(ReceiveCallback), socket);
                 }
             }
             catch (Exception ex)
             {
-                Log.Add(LogSeverity.ERROR, "Exception thrown " + ex.ToString());
-                CloseClient(index);
+                Log.Add(LogSeverity.ERROR, "Exception thrown " + ex);
+                CloseClient(Index);
             }
         }
 
         private void CloseClient(int index)
         {
-            Log.Add(LogSeverity.INFO, string.Format("Connection from {0} has been terminated.", ip));
-            closing = true;
-            socket.Close();
+            Log.Add(LogSeverity.INFO, string.Format("Connection from {0} has been terminated.", Ip));
+            Closing = true;
+            Socket.Close();
         }
     }
 }

--- a/BSGO Server/BSGO Server/Server/ProtocolManager.cs
+++ b/BSGO Server/BSGO Server/Server/ProtocolManager.cs
@@ -1,18 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace BSGO_Server
 {
     class ProtocolManager
     {
-        private static Dictionary<Protocol.ProtocolID, Protocol> protocols;
+        private static Dictionary<Protocol.ProtocolIDType, Protocol> protocols;
 
         public static void InitProtocols()
         {
             Log.Add(LogSeverity.SERVERINFO, "Initializing Protocols");
 
-            protocols = new Dictionary<Protocol.ProtocolID, Protocol>();
+            protocols = new Dictionary<Protocol.ProtocolIDType, Protocol>();
             RegisterProtocol(new LoginProtocol());
             RegisterProtocol(new SyncProtocol());
             RegisterProtocol(new SceneProtocol());
@@ -31,55 +30,56 @@ namespace BSGO_Server
 
         public static void HandleNetworkInformation(int index, byte[] data)
         {
-            BgoProtocolReader buffer = new BgoProtocolReader(data);
+            using BgoProtocolReader buffer = new BgoProtocolReader(data);
             buffer.ReadUInt16();
             byte protocolID = buffer.ReadByte();
 
-            Log.Add(LogSeverity.INFO, Log.LogDir.In, string.Format("Protocol ID: {0} ({1})", protocolID, (Protocol.ProtocolID)protocolID));
+            Log.Add(LogSeverity.INFO, Log.LogDir.In, string.Format("Protocol ID: {0} ({1})", protocolID, (Protocol.ProtocolIDType)protocolID));
 
             try
             {
-                GetProtocol((Protocol.ProtocolID)protocolID).ParseMessage(index, buffer);
+                GetProtocol((Protocol.ProtocolIDType)protocolID).ParseMessage(index, buffer);
             }
             catch (Exception ex)
             {
-                string text = "";
+                string text = string.Empty;
+                /*
+                 * stop using empty catch blocks eventually
+                */
                 try
                 {
-                    text += "Couldn't handle message for " + (Protocol.ProtocolID)protocolID + " Protocol";
+                    text += "Couldn't handle message for " + (Protocol.ProtocolIDType)protocolID + " Protocol";
                 } catch
                 {
-
+                    // throw;
                 }
                 try
                 {
                     text += " (msgType: " + buffer.ReadUInt16() + "). ";
                 } catch
                 {
-
+                    // throw;
                 }
-                if (GetProtocol((Protocol.ProtocolID)protocolID) == null)
+                if (GetProtocol((Protocol.ProtocolIDType)protocolID) is null)
                 {
                     text = text + protocolID + " Protocol is not (any more) registered. ";
                 }
-                text = text + "\nCaught Exception: " + ex.ToString();
+                text = text + "\nCaught Exception: " + ex;
                 Log.Add(LogSeverity.ERROR, text);
             }
-            buffer.Dispose();
         }
 
-        public static Protocol GetProtocol(Protocol.ProtocolID protoID)
+        public static Protocol GetProtocol(Protocol.ProtocolIDType protoID)
         {
             if (!protocols.ContainsKey(protoID))
-            {
                 return null;
-            }
+            
             return protocols[protoID];
         }
 
         private static void RegisterProtocol(Protocol protocol)
         {
-            protocols.Add(protocol.protocolID, protocol);
+            protocols.Add(protocol.ProtocolID, protocol);
         }
     }
 }

--- a/BSGO Server/BSGO Server/Server/ProtocolManager.cs
+++ b/BSGO Server/BSGO Server/Server/ProtocolManager.cs
@@ -45,7 +45,7 @@ namespace BSGO_Server
                 string text = string.Empty;
                 /*
                  * stop using empty catch blocks eventually
-                */
+                 */
                 try
                 {
                     text += "Couldn't handle message for " + (Protocol.ProtocolIDType)protocolID + " Protocol";
@@ -77,9 +77,8 @@ namespace BSGO_Server
             return protocols[protoID];
         }
 
-        private static void RegisterProtocol(Protocol protocol)
-        {
+        private static void RegisterProtocol(Protocol protocol) =>
             protocols.Add(protocol.ProtocolID, protocol);
-        }
+        
     }
 }

--- a/BSGO Server/BSGO Server/Server/ProtocolManager.cs
+++ b/BSGO Server/BSGO Server/Server/ProtocolManager.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace BSGO_Server
 {
-    class ProtocolManager
+    internal static class ProtocolManager
     {
         private static Dictionary<Protocol.ProtocolIDType, Protocol> protocols;
 
@@ -12,19 +12,20 @@ namespace BSGO_Server
             Log.Add(LogSeverity.SERVERINFO, "Initializing Protocols");
 
             protocols = new Dictionary<Protocol.ProtocolIDType, Protocol>();
-            RegisterProtocol(new LoginProtocol());
-            RegisterProtocol(new SyncProtocol());
-            RegisterProtocol(new SceneProtocol());
-            RegisterProtocol(new SettingProtocol());
-            RegisterProtocol(new CatalogueProtocol());
-            RegisterProtocol(new GameProtocol());
-            RegisterProtocol(new PlayerProtocol());
-            RegisterProtocol(new ShopProtocol());
-            RegisterProtocol(new CommunityProtocol());
-            RegisterProtocol(new FeedbackProtocol());
-            RegisterProtocol(new StoryProtocol());
-            RegisterProtocol(new SubscribeProtocol());
-
+            RegisterProtocol(new Protocol[] {
+                new LoginProtocol(),
+                new SyncProtocol(),
+                new SceneProtocol(),
+                new SettingProtocol(),
+                new CatalogueProtocol(),
+                new GameProtocol(),
+                new PlayerProtocol(),
+                new ShopProtocol(),
+                new CommunityProtocol(),
+                new FeedbackProtocol(),
+                new StoryProtocol(),
+                new SubscribeProtocol()
+            });
             Log.Add(LogSeverity.SERVERINFO, "Finished Initializing the Protocols");
         }
 
@@ -77,8 +78,11 @@ namespace BSGO_Server
             return protocols[protoID];
         }
 
-        private static void RegisterProtocol(Protocol protocol) =>
-            protocols.Add(protocol.ProtocolID, protocol);
+        private static void RegisterProtocol(params Protocol[] passedProtocols)
+        {
+            foreach (Protocol current in passedProtocols)
+                protocols.Add(current.ProtocolID, current);
+        }
         
     }
 }

--- a/BSGO Server/BSGO Server/Server/Protocols/CatalogueProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/CatalogueProtocol.cs
@@ -2,24 +2,24 @@
 {
     internal class CatalogueProtocol : Protocol
     {
-        public enum Request : byte
+        public enum Request : ushort
         {
             Card = 1
         }
 
-        public enum Reply : byte
+        public enum Reply : ushort
         {
             Card = 2
         }
 
         public CatalogueProtocol()
-            : base(ProtocolID.Catalogue)
+            : base(ProtocolIDType.Catalogue)
         {
         }
 
         public static CatalogueProtocol GetProtocol()
         {
-            return ProtocolManager.GetProtocol(ProtocolID.Catalogue) as CatalogueProtocol;
+            return ProtocolManager.GetProtocol(ProtocolIDType.Catalogue) as CatalogueProtocol;
         }
 
         public override void ParseMessage(int index, BgoProtocolReader br)

--- a/BSGO Server/BSGO Server/Server/Protocols/CatalogueProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/CatalogueProtocol.cs
@@ -1,23 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class CatalogueProtocol : Protocol
+    internal class CatalogueProtocol : Protocol
     {
-        public enum Request : ushort
+        public enum Request : byte
         {
             Card = 1
         }
 
-        public enum Reply : ushort
+        public enum Reply : byte
         {
             Card = 2
         }
 
         public CatalogueProtocol()
-    : base(ProtocolID.Catalogue)
+            : base(ProtocolID.Catalogue)
         {
         }
 
@@ -28,7 +24,7 @@ namespace BSGO_Server
 
         public override void ParseMessage(int index, BgoProtocolReader br)
         {
-            ushort msgType = (ushort)br.ReadUInt16();
+            ushort msgType = br.ReadUInt16();
 
             switch (msgType)
             {
@@ -39,20 +35,18 @@ namespace BSGO_Server
                     {
                         uint key = br.ReadUInt32();
                         ushort value = br.ReadUInt16();
-
                         SendCard(index, value, key);
                     }
-
                     break;
                 default:
-                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", msgType, protocolID));
+                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", msgType, ProtocolID));
                     break;
             }
         }
 
         private void SendCard(int index, ushort cardView, uint cardGuid)
         {
-            BgoProtocolWriter buffer = NewMessage();
+            using BgoProtocolWriter buffer = NewMessage();
             buffer.Write((ushort)Reply.Card);
 
             Card card = Catalogue.FetchCard(cardGuid, (CardView)cardView);

--- a/BSGO Server/BSGO Server/Server/Protocols/CommunityProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/CommunityProtocol.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class CommunityProtocol : Protocol
+    internal class CommunityProtocol : Protocol
     {
-        public enum Request : ushort
+        public enum Request : byte
         {
             PartyInvitePlayer = 1,
             PartyDismissPlayer = 2,
@@ -36,7 +32,7 @@ namespace BSGO_Server
             IgnoreClear = 35
         }
 
-        public enum Reply : ushort
+        public enum Reply : byte
         {
             Party = 1,
             PartyIgnore = 2,
@@ -71,18 +67,14 @@ namespace BSGO_Server
         }
 
         public CommunityProtocol()
-    : base(ProtocolID.Community)
-        {
-        }
+            : base(ProtocolID.Community) {}
 
-        public static CommunityProtocol GetProtocol()
-        {
-            return ProtocolManager.GetProtocol(ProtocolID.Community) as CommunityProtocol;
-        }
-
+        public static CommunityProtocol GetProtocol() =>
+            ProtocolManager.GetProtocol(ProtocolID.Community) as CommunityProtocol;
+        
         public override void ParseMessage(int index, BgoProtocolReader br)
         {
-            ushort msgType = (ushort)br.ReadUInt16();
+            ushort msgType = br.ReadUInt16();
 
             switch ((Request)msgType)
             {
@@ -90,14 +82,14 @@ namespace BSGO_Server
                     SendRecruitLevel(index);
                     break;
                 default:
-                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, protocolID));
+                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, ProtocolID));
                     break;
             }
         }
 
         private void SendRecruitLevel(int index)
         {
-            BgoProtocolWriter buffer = NewMessage();
+            using BgoProtocolWriter buffer = NewMessage();
             buffer.Write((ushort)Reply.RecruitLevel);
             buffer.Write((uint)1); // idk
 

--- a/BSGO Server/BSGO Server/Server/Protocols/CommunityProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/CommunityProtocol.cs
@@ -2,7 +2,7 @@
 {
     internal class CommunityProtocol : Protocol
     {
-        public enum Request : byte
+        public enum Request : ushort
         {
             PartyInvitePlayer = 1,
             PartyDismissPlayer = 2,
@@ -32,7 +32,7 @@
             IgnoreClear = 35
         }
 
-        public enum Reply : byte
+        public enum Reply : ushort
         {
             Party = 1,
             PartyIgnore = 2,
@@ -67,10 +67,10 @@
         }
 
         public CommunityProtocol()
-            : base(ProtocolID.Community) {}
+            : base(ProtocolIDType.Community) {}
 
         public static CommunityProtocol GetProtocol() =>
-            ProtocolManager.GetProtocol(ProtocolID.Community) as CommunityProtocol;
+            ProtocolManager.GetProtocol(ProtocolIDType.Community) as CommunityProtocol;
         
         public override void ParseMessage(int index, BgoProtocolReader br)
         {

--- a/BSGO Server/BSGO Server/Server/Protocols/FeedbackProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/FeedbackProtocol.cs
@@ -1,18 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
     class FeedbackProtocol : Protocol
     {
-        public enum MessageId : ushort
+        public enum MessageId : byte
         {
             UiElementShown,
             UiElementHidden
         }
 
-        public enum UiElementId : ushort
+        public enum UiElementId : byte
         {
             ShopWindow,
             RepairWindow,
@@ -28,23 +24,20 @@ namespace BSGO_Server
         {
         }
 
-        public static FeedbackProtocol GetProtocol()
-        {
-            return ProtocolManager.GetProtocol(ProtocolID.Feedback) as FeedbackProtocol;
-        }
-
+        public static FeedbackProtocol GetProtocol() =>
+            ProtocolManager.GetProtocol(ProtocolID.Feedback) as FeedbackProtocol;
+        
         public override void ParseMessage(int index, BgoProtocolReader br)
         {
-            ushort messageId = (ushort)br.ReadUInt16();
-            ushort uiElement = br.ReadUInt16(); ;
+            ushort messageId = br.ReadUInt16();
 
             switch (messageId)
             {
                 case 0:
-                    Log.Add(LogSeverity.INFO, string.Format("The element {0} is shown.", (UiElementId)uiElement));
+                    Log.Add(LogSeverity.INFO, string.Format("The element {0} is shown.", (UiElementId)messageId));
                     break;
                 case 1:
-                    Log.Add(LogSeverity.INFO, string.Format("The element {0} is hidden.", (UiElementId)uiElement));
+                    Log.Add(LogSeverity.INFO, string.Format("The element {0} is hidden.", (UiElementId)messageId));
                     break;
             }
         }

--- a/BSGO Server/BSGO Server/Server/Protocols/FeedbackProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/FeedbackProtocol.cs
@@ -29,15 +29,16 @@
         
         public override void ParseMessage(int index, BgoProtocolReader br)
         {
+            ushort uiElement = br.ReadUInt16();
             ushort messageId = br.ReadUInt16();
 
             switch (messageId)
             {
                 case 0:
-                    Log.Add(LogSeverity.INFO, string.Format("The element {0} is shown.", (UiElementId)messageId));
+                    Log.Add(LogSeverity.INFO, string.Format("The element {0} is shown.", (UiElementId)uiElement));
                     break;
                 case 1:
-                    Log.Add(LogSeverity.INFO, string.Format("The element {0} is hidden.", (UiElementId)messageId));
+                    Log.Add(LogSeverity.INFO, string.Format("The element {0} is hidden.", (UiElementId)uiElement));
                     break;
             }
         }

--- a/BSGO Server/BSGO Server/Server/Protocols/FeedbackProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/FeedbackProtocol.cs
@@ -2,13 +2,13 @@
 {
     class FeedbackProtocol : Protocol
     {
-        public enum MessageId : byte
+        public enum MessageId : ushort
         {
             UiElementShown,
             UiElementHidden
         }
 
-        public enum UiElementId : byte
+        public enum UiElementId : ushort
         {
             ShopWindow,
             RepairWindow,
@@ -20,12 +20,12 @@
         }
 
         public FeedbackProtocol()
-            : base(ProtocolID.Feedback)
+            : base(ProtocolIDType.Feedback)
         {
         }
 
         public static FeedbackProtocol GetProtocol() =>
-            ProtocolManager.GetProtocol(ProtocolID.Feedback) as FeedbackProtocol;
+            ProtocolManager.GetProtocol(ProtocolIDType.Feedback) as FeedbackProtocol;
         
         public override void ParseMessage(int index, BgoProtocolReader br)
         {

--- a/BSGO Server/BSGO Server/Server/Protocols/GameProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/GameProtocol.cs
@@ -101,11 +101,11 @@ namespace BSGO_Server
         }
 
         public GameProtocol()
-            : base(ProtocolIDType.Game) {}
+            : base(ProtocolIDType.Game) { }
 
         public static GameProtocol GetProtocol() =>
             ProtocolManager.GetProtocol(ProtocolIDType.Game) as GameProtocol;
-        
+
         public override void ParseMessage(int index, BgoProtocolReader br)
         {
             ushort msgType = br.ReadUInt16();
@@ -259,7 +259,7 @@ namespace BSGO_Server
             buffer.Write((ushort)0);
             buffer.Write((ushort)0);
 
-            buffer.Write(Server.GetClientByIndex(index).playerId); //player id
+            buffer.Write(Server.GetClientByIndex(index).PlayerId); //player id
             buffer.Write((uint)BgoAdminRoles.Developer); //player role
             buffer.Write(true);
 

--- a/BSGO Server/BSGO Server/Server/Protocols/GameProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/GameProtocol.cs
@@ -5,7 +5,7 @@ namespace BSGO_Server
 {
     class GameProtocol : Protocol
     {
-        public enum Reply : byte
+        public enum Reply : ushort
         {
             Info = 2,
             WhoIs = 4,
@@ -52,7 +52,7 @@ namespace BSGO_Server
             CargoInteraction = 106
         }
 
-        public enum Request : byte
+        public enum Request : ushort
         {
             WhoIs = 3,
             SubscribeInfo = 10,
@@ -101,10 +101,10 @@ namespace BSGO_Server
         }
 
         public GameProtocol()
-            : base(ProtocolID.Game) {}
+            : base(ProtocolIDType.Game) {}
 
         public static GameProtocol GetProtocol() =>
-            ProtocolManager.GetProtocol(ProtocolID.Game) as GameProtocol;
+            ProtocolManager.GetProtocol(ProtocolIDType.Game) as GameProtocol;
         
         public override void ParseMessage(int index, BgoProtocolReader br)
         {

--- a/BSGO Server/BSGO Server/Server/Protocols/LoginProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/LoginProtocol.cs
@@ -41,15 +41,16 @@ namespace BSGO_Server
                     ConnectType connectType = (ConnectType)br.ReadByte();
                     // Check if the player exists on our database. We'll have checks for client connected later, but it's
                     // not necessary yet
-                    uint playerId = br.ReadUInt32();
-                    string playerName = br.ReadString();
+
+                    // uint playerId = br.ReadUInt32();
+                    // string playerName = br.ReadString();
                     string sessionCode = br.ReadString();
 
                     switch (connectType) {
                         case ConnectType.Web:
                             if (Database.Database.CheckSessionCodeExistance(sessionCode))
                             {
-                                playerId = Convert.ToUInt32(Database.Database.GetUserBySession(sessionCode).PlayerId);
+                                uint playerId = Convert.ToUInt32(Database.Database.GetUserBySession(sessionCode).PlayerId);
                                 Server.GetClientByIndex(index).playerId = playerId;
                                 Server.GetClientByIndex(index).Character = new Character(index);
                                 SendPlayer(index);

--- a/BSGO Server/BSGO Server/Server/Protocols/LoginProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/LoginProtocol.cs
@@ -22,11 +22,11 @@ namespace BSGO_Server
         }
 
         public LoginProtocol()
-            : base(ProtocolIDType.Login) {}
+            : base(ProtocolIDType.Login) { }
 
         public static LoginProtocol GetProtocol() =>
             ProtocolManager.GetProtocol(ProtocolIDType.Login) as LoginProtocol;
-        
+
         public override void ParseMessage(int index, BgoProtocolReader br)
         {
             ushort msgType = br.ReadUInt16();
@@ -46,12 +46,13 @@ namespace BSGO_Server
                     string playerName = br.ReadString();
                     string sessionCode = br.ReadString();
 
-                    switch (connectType) {
+                    switch (connectType)
+                    {
                         case ConnectType.Web:
                             if (Database.Database.CheckSessionCodeExistance(sessionCode))
                             {
                                 playerId = Convert.ToUInt32(Database.Database.GetUserBySession(sessionCode).PlayerId);
-                                Server.GetClientByIndex(index).playerId = playerId;
+                                Server.GetClientByIndex(index).PlayerId = playerId;
                                 Server.GetClientByIndex(index).Character = new Character(index);
                                 SendPlayer(index);
                                 /*
@@ -67,7 +68,7 @@ namespace BSGO_Server
                             Log.Add(LogSeverity.ERROR, "Unknown Connection Type " + connectType + " on Login Protocol");
                             break;
                     }
-                       
+
                     break;
                 default:
                     Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, ProtocolID));

--- a/BSGO Server/BSGO Server/Server/Protocols/LoginProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/LoginProtocol.cs
@@ -42,15 +42,15 @@ namespace BSGO_Server
                     // Check if the player exists on our database. We'll have checks for client connected later, but it's
                     // not necessary yet
 
-                    // uint playerId = br.ReadUInt32();
-                    // string playerName = br.ReadString();
+                    uint playerId = br.ReadUInt32();
+                    string playerName = br.ReadString();
                     string sessionCode = br.ReadString();
 
                     switch (connectType) {
                         case ConnectType.Web:
                             if (Database.Database.CheckSessionCodeExistance(sessionCode))
                             {
-                                uint playerId = Convert.ToUInt32(Database.Database.GetUserBySession(sessionCode).PlayerId);
+                                playerId = Convert.ToUInt32(Database.Database.GetUserBySession(sessionCode).PlayerId);
                                 Server.GetClientByIndex(index).playerId = playerId;
                                 Server.GetClientByIndex(index).Character = new Character(index);
                                 SendPlayer(index);

--- a/BSGO Server/BSGO Server/Server/Protocols/LoginProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/LoginProtocol.cs
@@ -4,7 +4,7 @@ namespace BSGO_Server
 {
     internal class LoginProtocol : Protocol
     {
-        public enum Reply : byte
+        public enum Reply : ushort
         {
             Hello,
             Init,
@@ -14,7 +14,7 @@ namespace BSGO_Server
             Echo
         }
 
-        public enum Request : byte
+        public enum Request : ushort
         {
             Init = 1,
             Player = 2,
@@ -22,10 +22,10 @@ namespace BSGO_Server
         }
 
         public LoginProtocol()
-            : base(ProtocolID.Login) {}
+            : base(ProtocolIDType.Login) {}
 
         public static LoginProtocol GetProtocol() =>
-            ProtocolManager.GetProtocol(ProtocolID.Login) as LoginProtocol;
+            ProtocolManager.GetProtocol(ProtocolIDType.Login) as LoginProtocol;
         
         public override void ParseMessage(int index, BgoProtocolReader br)
         {

--- a/BSGO Server/BSGO Server/Server/Protocols/Others/BgoProtocolReader.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/Others/BgoProtocolReader.cs
@@ -5,17 +5,13 @@ using System.Text;
 
 namespace BSGO_Server
 {
-    class BgoProtocolReader : BinaryReader
+    internal class BgoProtocolReader : BinaryReader
     {
         public BgoProtocolReader(byte[] buffer)
-        : this(new MemoryStream(buffer))
-        {
-        }
+        : this(new MemoryStream(buffer)) { }
 
         public BgoProtocolReader(MemoryStream stream)
-            : base(stream)
-        {
-        }
+            : base(stream) { }
 
         public BgoProtocolReader UnZip()
         {
@@ -37,8 +33,8 @@ namespace BSGO_Server
             {
                 byte[] array = new byte[num];
                 Read(array, 0, array.Length);
-                Encoding uTF = Encoding.UTF8;
-                return uTF.GetString(array);
+                Encoding utf = Encoding.UTF8;
+                return utf.GetString(array);
             }
             return string.Empty;
         }
@@ -48,9 +44,8 @@ namespace BSGO_Server
             int num = ReadLength();
             string[] array = new string[num];
             for (int i = 0; i < num; i++)
-            {
                 array[i] = ReadString();
-            }
+            
             return array;
         }
 
@@ -59,9 +54,8 @@ namespace BSGO_Server
             int num = ReadLength();
             byte[] array = new byte[num];
             for (int i = 0; i < num; i++)
-            {
                 array[i] = ReadByte();
-            }
+            
             return array;
         }
 
@@ -77,9 +71,8 @@ namespace BSGO_Server
             int num = ReadLength();
             List<T> list = new List<T>();
             for (int i = 0; i < num; i++)
-            {
                 list.Add(ReadDesc<T>());
-            }
+            
             return list;
         }
 
@@ -88,9 +81,8 @@ namespace BSGO_Server
             int num = ReadLength();
             List<ushort> list = new List<ushort>();
             for (int i = 0; i < num; i++)
-            {
                 list.Add(ReadUInt16());
-            }
+            
             return list;
         }
 
@@ -99,9 +91,8 @@ namespace BSGO_Server
             int num = ReadLength();
             List<uint> list = new List<uint>();
             for (int i = 0; i < num; i++)
-            {
                 list.Add(ReadUInt32());
-            }
+            
             return list;
         }
 
@@ -110,9 +101,8 @@ namespace BSGO_Server
             int num = ReadLength();
             T[] array = new T[num];
             for (int i = 0; i < num; i++)
-            {
                 array[i] = ReadDesc<T>();
-            }
+            
             return array;
         }
 
@@ -121,41 +111,31 @@ namespace BSGO_Server
             ushort num = ReadUInt16();
             HashSet<T> hashSet = new HashSet<T>();
             for (int num2 = 1; num2 < 65536; num2 <<= 1)
-            {
                 if ((num & num2) != 0)
-                {
                     hashSet.Add((T)Enum.ToObject(typeof(T), num2));
-                }
-            }
+                
             return hashSet;
         }
 
-        public int ReadLength()
-        {
-            return ReadUInt16();
-        }
-
-
-        public DateTime ReadDateTime()
-        {
-            return new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddSeconds(ReadUInt32());
-        }
+        public int ReadLength() =>
+            ReadUInt16();
+        
+        public DateTime ReadDateTime() =>
+            new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddSeconds(ReadUInt32());
+        
 
         public DateTime ReadLongDateTime()
         {
             ulong num = ReadUInt64();
             if (num != 0L)
-            {
                 return new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddSeconds(num);
-            }
-            return default(DateTime);
+
+            return default;
         }
 
-        public uint ReadGUID()
-        {
-            return ReadUInt32();
-        }
-
+        public uint ReadGUID() =>
+            ReadUInt32();
+        
         public static ushort ReadBufferSize(byte[] data)
         {
             ushort num = data[0];

--- a/BSGO Server/BSGO Server/Server/Protocols/Others/BgoProtocolWriter.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/Others/BgoProtocolWriter.cs
@@ -1,15 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
+﻿using System.Drawing;
 using System.IO;
 using System.Numerics;
 using System.Text;
 
 namespace BSGO_Server
 {
-    class BgoProtocolWriter : BinaryWriter
+    internal class BgoProtocolWriter : BinaryWriter
     {
-        private MemoryStream memoryStream;
+        private readonly MemoryStream memoryStream;
 
         public BgoProtocolWriter()
             : base(new MemoryStream())
@@ -31,18 +29,16 @@ namespace BSGO_Server
             byte[] bytes = uTF.GetBytes(value);
             Write((ushort)bytes.Length);
             if (bytes.Length > 0)
-            {
                 Write(bytes, 0, bytes.Length);
-            }
+            
         }
 
         public void Write(string[] value)
         {
             Write((ushort)value.Length);
             for(int i = 0; i < value.Length; i++)
-            {
                 Write(value[i]);
-            }
+            
         }
 
         public void Write(Color value)
@@ -81,9 +77,8 @@ namespace BSGO_Server
             return buffer;
         }
 
-        public int GetLength()
-        {
-            return (int)memoryStream.Length;
-        }
+        public int GetLength() =>
+            (int)memoryStream.Length;
+        
     }
 }

--- a/BSGO Server/BSGO Server/Server/Protocols/Others/IProtocolRead.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/Others/IProtocolRead.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    interface IProtocolRead
+    internal interface IProtocolRead
     {
         void Read(BgoProtocolReader r);
     }

--- a/BSGO Server/BSGO Server/Server/Protocols/Others/IProtocolWrite.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/Others/IProtocolWrite.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    interface IProtocolWrite
+    internal interface IProtocolWrite
     {
         void Write(BgoProtocolWriter w);
     }

--- a/BSGO Server/BSGO Server/Server/Protocols/PlayerProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/PlayerProtocol.cs
@@ -136,13 +136,13 @@ namespace BSGO_Server
         }
 
         public PlayerProtocol()
-            : base(ProtocolID.Player)
+            : base(ProtocolIDType.Player)
         {
         }
 
         public static PlayerProtocol GetProtocol()
         {
-            return ProtocolManager.GetProtocol(ProtocolID.Player) as PlayerProtocol;
+            return ProtocolManager.GetProtocol(ProtocolIDType.Player) as PlayerProtocol;
         }
 
         public void SendPlayerID()

--- a/BSGO Server/BSGO Server/Server/Protocols/PlayerProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/PlayerProtocol.cs
@@ -152,7 +152,7 @@ namespace BSGO_Server
 
         public override void ParseMessage(int index, BgoProtocolReader br)
         {
-            ushort msgType = (ushort)br.ReadUInt16();
+            ushort msgType = br.ReadUInt16();
 
             switch ((Request)msgType)
             {
@@ -178,14 +178,13 @@ namespace BSGO_Server
                     Dictionary<AvatarItem, string> items = new Dictionary<AvatarItem, string>();
 
                     int num = br.ReadLength();
-                    for (int i = 0; i < num; i++)
-                    {
-                        items[(AvatarItem)br.ReadByte()] = br.ReadString();
-                    }
 
+                    for (int i = 0; i < num; i++)
+                        items[(AvatarItem)br.ReadByte()] = br.ReadString();
+                    
                     Client client = Server.GetClientByIndex(index);
 
-                    Database.Database.CreateCharacter(client.Character.Name, client.playerId.ToString(), (byte)client.Character.Faction, items);
+                    Database.Database.CreateCharacter(client.Character.Name, client.PlayerId.ToString(), (byte)client.Character.Faction, items);
 
                     Server.GetClientByIndex(index).Character.Items = items;
                     SendAvatar(index);
@@ -306,7 +305,7 @@ namespace BSGO_Server
         {
             BgoProtocolWriter buffer = NewMessage();
             buffer.Write((ushort)Reply.ID);
-            buffer.Write(Server.GetClientByIndex(index).playerId);
+            buffer.Write(Server.GetClientByIndex(index).PlayerId);
 
             SendMessageToUser(index, buffer);
         }

--- a/BSGO Server/BSGO Server/Server/Protocols/PlayerProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/PlayerProtocol.cs
@@ -171,7 +171,7 @@ namespace BSGO_Server
                     SendNameAvailability(index, br.ReadString());
                     break;
                 case Request.ChooseName:
-                    Server.GetClientByIndex(index).Character.name = br.ReadString();
+                    Server.GetClientByIndex(index).Character.Name = br.ReadString();
                     SendName(index);
                     break;
                 case Request.CreateAvatar:
@@ -185,9 +185,9 @@ namespace BSGO_Server
 
                     Client client = Server.GetClientByIndex(index);
 
-                    Database.Database.CreateCharacter(client.Character.name, client.playerId.ToString(), (byte)client.Character.Faction, items);
+                    Database.Database.CreateCharacter(client.Character.Name, client.playerId.ToString(), (byte)client.Character.Faction, items);
 
-                    Server.GetClientByIndex(index).Character.items = items;
+                    Server.GetClientByIndex(index).Character.Items = items;
                     SendAvatar(index);
 
                     SendPlayerId(index);
@@ -196,7 +196,7 @@ namespace BSGO_Server
                     Server.GetClientByIndex(index).Character.GameLocation = GameLocation.Space;
                     break;
                 default:
-                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, protocolID));
+                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, ProtocolID));
                     break;
             }
         }
@@ -236,7 +236,8 @@ namespace BSGO_Server
             if (Database.Database.CheckCharacterNameAvailability(name))
             {
                 buffer.Write((ushort)20);
-            } else
+            }
+            else
             {
                 buffer.Write((ushort)21);
             }
@@ -248,7 +249,7 @@ namespace BSGO_Server
         {
             BgoProtocolWriter buffer = NewMessage();
             buffer.Write((ushort)23);
-            buffer.Write(Server.GetClientByIndex(index).Character.name);
+            buffer.Write(Server.GetClientByIndex(index).Character.Name);
 
             SendMessageToUser(index, buffer);
         }
@@ -258,7 +259,7 @@ namespace BSGO_Server
             BgoProtocolWriter buffer = NewMessage();
             buffer.Write((ushort)29);
 
-            Dictionary<AvatarItem, string> items = Server.GetClientByIndex(index).Character.items;
+            Dictionary<AvatarItem, string> items = Server.GetClientByIndex(index).Character.Items;
 
             buffer.Write((ushort)items.Count);
             foreach (KeyValuePair<AvatarItem, string> item in items)

--- a/BSGO Server/BSGO Server/Server/Protocols/Protocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/Protocol.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace BSGO_Server
 {
-    class Protocol
+    internal class Protocol
     {
-        public enum ProtocolID : byte
+        public enum ProtocolIDType : byte
         {
             Login,
             Universe,
@@ -36,13 +34,13 @@ namespace BSGO_Server
             Zone
         }
 
-        public readonly ProtocolID protocolID;
+        public ProtocolIDType ProtocolID { get; }
 
-        private bool enabled;
+        private readonly bool enabled;
 
-        public Protocol(ProtocolID protocolID)
+        public Protocol(ProtocolIDType protocolID)
         {
-            this.protocolID = protocolID;
+            ProtocolID = protocolID;
             enabled = true;
         }
 
@@ -51,7 +49,7 @@ namespace BSGO_Server
         protected BgoProtocolWriter NewMessage()
         {
             BgoProtocolWriter bgoProtocolWriter = new BgoProtocolWriter();
-            bgoProtocolWriter.Write((byte)protocolID);
+            bgoProtocolWriter.Write((byte)ProtocolID);
             return bgoProtocolWriter;
         }
 
@@ -63,13 +61,13 @@ namespace BSGO_Server
                 DebugMessage(bw);
             }
             else
-            {
-                Log.Add(LogSeverity.ERROR, string.Format("Trying to send message to \"{0}\" for disabled protocol \"{1}\"", index, protocolID));
-            }
+                Log.Add(LogSeverity.ERROR, string.Format("Trying to send message to \"{0}\" for disabled protocol \"{1}\"", index, ProtocolID));
+            
         }
 
         protected void SendMessageToSector(int index, BgoProtocolWriter bw)
         {
+            // ?
             if (enabled)
             {
 
@@ -82,22 +80,23 @@ namespace BSGO_Server
 
         protected void SendMessageToEveryone(BgoProtocolWriter bw)
         {
+            // ?
             if (enabled)
             {
 
             }
             else
             {
-                Log.Add(LogSeverity.ERROR, string.Format("Trying to send message to everyone for disabled protocol \"{0}\"", protocolID));
+                Log.Add(LogSeverity.ERROR, string.Format("Trying to send message to everyone for disabled protocol \"{0}\"", ProtocolID));
             }
         }
 
         private void DebugMessage(BgoProtocolWriter w)
         {
-            BgoProtocolReader buffer = new BgoProtocolReader(w.GetBuffer());
+            using BgoProtocolReader buffer = new BgoProtocolReader(w.GetBuffer());
             buffer.ReadUInt16();
             byte protocolId = buffer.ReadByte();
-            Log.Add(LogSeverity.INFO, Log.LogDir.Out, string.Format("Protocol ID: {0} ({1}) - msgType: {2}", protocolId, (ProtocolID)protocolId, buffer.ReadUInt16()));
+            Log.Add(LogSeverity.INFO, Log.LogDir.Out, string.Format("Protocol ID: {0} ({1}) - msgType: {2}", protocolId, (ProtocolIDType)protocolId, buffer.ReadUInt16()));
         }
     }
 }

--- a/BSGO Server/BSGO Server/Server/Protocols/Protocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/Protocol.cs
@@ -2,7 +2,7 @@
 
 namespace BSGO_Server
 {
-    internal class Protocol
+    internal abstract class Protocol
     {
         public enum ProtocolIDType : byte
         {
@@ -38,13 +38,13 @@ namespace BSGO_Server
 
         private readonly bool enabled;
 
-        public Protocol(ProtocolIDType protocolID)
+        protected Protocol(ProtocolIDType protocolID)
         {
             ProtocolID = protocolID;
             enabled = true;
         }
 
-        public virtual void ParseMessage(int index, BgoProtocolReader br) { }
+        public abstract void ParseMessage(int index, BgoProtocolReader br);
 
         protected BgoProtocolWriter NewMessage()
         {
@@ -62,10 +62,12 @@ namespace BSGO_Server
             }
             else
                 Log.Add(LogSeverity.ERROR, string.Format("Trying to send message to \"{0}\" for disabled protocol \"{1}\"", index, ProtocolID));
-            
+
+            bw.Dispose();
         }
 
-        protected void SendMessageToSector(int index, BgoProtocolWriter bw)
+        // unused params, method is unfinished?
+        protected void SendMessageToSector(/* int index, BgoProtocolWriter bw */)
         {
             // ?
             if (enabled)
@@ -78,7 +80,8 @@ namespace BSGO_Server
             }
         }
 
-        protected void SendMessageToEveryone(BgoProtocolWriter bw)
+        // unused params, method is unfinished?
+        protected void SendMessageToEveryone(/* BgoProtocolWriter bw */)
         {
             // ?
             if (enabled)

--- a/BSGO Server/BSGO Server/Server/Protocols/SceneProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/SceneProtocol.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class SceneProtocol : Protocol
+    internal class SceneProtocol : Protocol
     {
         public enum Request : ushort
         {
@@ -22,18 +18,14 @@ namespace BSGO_Server
         }
 
         public SceneProtocol()
-            : base(ProtocolID.Scene)
-        {
-        }
+            : base(ProtocolID.Scene) {}
 
-        public static SceneProtocol GetProtocol()
-        {
-            return ProtocolManager.GetProtocol(ProtocolID.Scene) as SceneProtocol;
-        }
-
+        public static SceneProtocol GetProtocol() =>
+            ProtocolManager.GetProtocol(ProtocolID.Scene) as SceneProtocol;
+        
         public override void ParseMessage(int index, BgoProtocolReader br)
         {
-            ushort msgType = (ushort)br.ReadUInt16();
+            ushort msgType = br.ReadUInt16();
 
             switch ((Request)msgType)
             {
@@ -44,7 +36,7 @@ namespace BSGO_Server
                     SceneLoaded(index);
                     break;
                 default:
-                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, protocolID));
+                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, ProtocolID));
                     break;
             }
         }
@@ -54,12 +46,12 @@ namespace BSGO_Server
         // There are multiple locations to send such as Space, Room, Story etc.
         public void SendLoadNextScene(int index)
         {
-            BgoProtocolWriter buffer = NewMessage();
+            using BgoProtocolWriter buffer = NewMessage();
             buffer.Write((ushort)Reply.LoadNextScene);
 
             Character charIndex = Server.GetClientByIndex(index).Character;
 
-            buffer.Write((byte)charIndex.getTransSceneType());
+            buffer.Write((byte)charIndex.GetTransSceneType());
             buffer.Write((byte)charIndex.GameLocation);
 
             switch (charIndex.GameLocation)
@@ -73,7 +65,6 @@ namespace BSGO_Server
                     buffer.Write(false); // No idea since the game doesn't use this.
                     break;
                 case GameLocation.Room:
-
                     break;
                 case GameLocation.Space:
                 case GameLocation.Story:
@@ -88,7 +79,7 @@ namespace BSGO_Server
                     PlayerProtocol.GetProtocol().SendName(index);
                     PlayerProtocol.GetProtocol().SendAvatar(index);
                     PlayerProtocol.GetProtocol().SendFaction(index);
-                    PlayerProtocol.GetProtocol().SendPlayerShips(index, 100, (uint)22131177);
+                    PlayerProtocol.GetProtocol().SendPlayerShips(index, 100, 22131177);
 
                     PlayerProtocol.GetProtocol().SetActivePlayerShip(index, 100);
 

--- a/BSGO Server/BSGO Server/Server/Protocols/SceneProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/SceneProtocol.cs
@@ -18,10 +18,10 @@
         }
 
         public SceneProtocol()
-            : base(ProtocolID.Scene) {}
+            : base(ProtocolIDType.Scene) {}
 
         public static SceneProtocol GetProtocol() =>
-            ProtocolManager.GetProtocol(ProtocolID.Scene) as SceneProtocol;
+            ProtocolManager.GetProtocol(ProtocolIDType.Scene) as SceneProtocol;
         
         public override void ParseMessage(int index, BgoProtocolReader br)
         {

--- a/BSGO Server/BSGO Server/Server/Protocols/SettingProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/SettingProtocol.cs
@@ -2,7 +2,7 @@
 {
     internal class SettingProtocol : Protocol
     {
-        public enum Request : byte
+        public enum Request : ushort
         {
             SaveSettings = 1,
             SaveKeys = 2,
@@ -10,17 +10,17 @@
             SetFullScreen = 6
         }
 
-        public enum Reply : byte
+        public enum Reply : ushort
         {
             Settings = 3,
             Keys
         }
 
         public SettingProtocol()
-            : base(ProtocolID.Setting) { }
+            : base(ProtocolIDType.Setting) { }
 
         public static SettingProtocol GetProtocol()
-            => ProtocolManager.GetProtocol(ProtocolID.Setting) as SettingProtocol;
+            => ProtocolManager.GetProtocol(ProtocolIDType.Setting) as SettingProtocol;
         
         public override void ParseMessage(int index, BgoProtocolReader br)
         {

--- a/BSGO Server/BSGO Server/Server/Protocols/SettingProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/SettingProtocol.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class SettingProtocol : Protocol
+    internal class SettingProtocol : Protocol
     {
-        public enum Request : ushort
+        public enum Request : byte
         {
             SaveSettings = 1,
             SaveKeys = 2,
@@ -14,30 +10,27 @@ namespace BSGO_Server
             SetFullScreen = 6
         }
 
-        public enum Reply : ushort
+        public enum Reply : byte
         {
             Settings = 3,
             Keys
         }
 
         public SettingProtocol()
-            : base(ProtocolID.Setting)
-        {
-        }
+            : base(ProtocolID.Setting) { }
 
         public static SettingProtocol GetProtocol()
-        {
-            return ProtocolManager.GetProtocol(ProtocolID.Setting) as SettingProtocol;
-        }
-
+            => ProtocolManager.GetProtocol(ProtocolID.Setting) as SettingProtocol;
+        
         public override void ParseMessage(int index, BgoProtocolReader br)
         {
-            ushort msgType = (ushort)br.ReadUInt16();
+            ushort msgType = br.ReadUInt16();
 
-            switch ((Request)msgType)
+            // ?
+            switch (msgType)
             {
                 default:
-                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, protocolID));
+                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, ProtocolID));
                     break;
             }
         }

--- a/BSGO Server/BSGO Server/Server/Protocols/ShopProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/ShopProtocol.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class ShopProtocol : Protocol
+    internal class ShopProtocol : Protocol
     {
         public enum Request : ushort
         {
@@ -27,18 +23,14 @@ namespace BSGO_Server
         }
 
         public ShopProtocol()
-    : base(ProtocolID.Shop)
-        {
-        }
+            : base(ProtocolID.Shop) { }
 
-        public static ShopProtocol GetProtocol()
-        {
-            return ProtocolManager.GetProtocol(ProtocolID.Shop) as ShopProtocol;
-        }
-
+        public static ShopProtocol GetProtocol() =>
+            ProtocolManager.GetProtocol(ProtocolID.Shop) as ShopProtocol;
+        
         public override void ParseMessage(int index, BgoProtocolReader br)
         {
-            ushort msgType = (ushort)br.ReadUInt16();
+            ushort msgType = br.ReadUInt16();
 
             switch ((Request)msgType)
             {
@@ -46,14 +38,14 @@ namespace BSGO_Server
                     SendItems(index);
                     break;
                 default:
-                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, protocolID));
+                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, ProtocolID));
                     break;
             }
         }
 
         private void SendItems(int index)
         {
-            BgoProtocolWriter buffer = NewMessage();
+            using BgoProtocolWriter buffer = NewMessage();
             buffer.Write((ushort)Reply.Items);
             buffer.Write((ushort)0); // No items since I don't know what to send.
 

--- a/BSGO Server/BSGO Server/Server/Protocols/ShopProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/ShopProtocol.cs
@@ -23,10 +23,10 @@
         }
 
         public ShopProtocol()
-            : base(ProtocolID.Shop) { }
+            : base(ProtocolIDType.Shop) { }
 
         public static ShopProtocol GetProtocol() =>
-            ProtocolManager.GetProtocol(ProtocolID.Shop) as ShopProtocol;
+            ProtocolManager.GetProtocol(ProtocolIDType.Shop) as ShopProtocol;
         
         public override void ParseMessage(int index, BgoProtocolReader br)
         {

--- a/BSGO Server/BSGO Server/Server/Protocols/StoryProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/StoryProtocol.cs
@@ -2,7 +2,7 @@
 {
     internal class StoryProtocol : Protocol
     {
-        public enum Reply : byte
+        public enum Reply : ushort
         {
             BannerBox = 1,
             MessageBox,
@@ -26,7 +26,7 @@
             AskContinue
         }
 
-        public enum Request : byte
+        public enum Request : ushort
         {
             TriggerControl = 1,
             MessageBoxOk,
@@ -38,7 +38,7 @@
             LookingAtTrigger
         }
 
-        public enum ControlType : byte
+        public enum ControlType : ushort
         {
             TargetEnemy = 19,
             TargetAlly = 20,
@@ -80,10 +80,10 @@
         }
 
         public StoryProtocol()
-            : base(ProtocolID.Story) { }
+            : base(ProtocolIDType.Story) { }
 
         public static StoryProtocol GetProtocol() =>
-            ProtocolManager.GetProtocol(ProtocolID.Story) as StoryProtocol;
+            ProtocolManager.GetProtocol(ProtocolIDType.Story) as StoryProtocol;
         
 
         public override void ParseMessage(int index, BgoProtocolReader br)

--- a/BSGO Server/BSGO Server/Server/Protocols/StoryProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/StoryProtocol.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BSGO_Server
+﻿namespace BSGO_Server
 {
-    class StoryProtocol : Protocol
+    internal class StoryProtocol : Protocol
     {
-        public enum Reply : ushort
+        public enum Reply : byte
         {
             BannerBox = 1,
             MessageBox,
@@ -30,7 +26,7 @@ namespace BSGO_Server
             AskContinue
         }
 
-        public enum Request : ushort
+        public enum Request : byte
         {
             TriggerControl = 1,
             MessageBoxOk,
@@ -84,31 +80,27 @@ namespace BSGO_Server
         }
 
         public StoryProtocol()
-    : base(ProtocolID.Story)
-        {
-        }
+            : base(ProtocolID.Story) { }
 
-        public static StoryProtocol GetProtocol()
-        {
-            return ProtocolManager.GetProtocol(ProtocolID.Story) as StoryProtocol;
-        }
+        public static StoryProtocol GetProtocol() =>
+            ProtocolManager.GetProtocol(ProtocolID.Story) as StoryProtocol;
+        
 
         public override void ParseMessage(int index, BgoProtocolReader br)
         {
-            ushort msgType = (ushort)br.ReadUInt16();
+            ushort msgType = br.ReadUInt16();
 
-            switch ((Request)msgType)
+            switch (msgType)
             {
-
                 default:
-                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, protocolID));
+                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, ProtocolID));
                     break;
             }
         }
 
         public void EnableGear(int index, bool enable)
         {
-            BgoProtocolWriter buffer = NewMessage();
+            using BgoProtocolWriter buffer = NewMessage();
             buffer.Write((ushort)Reply.EnableGear);
 
             buffer.Write(enable);

--- a/BSGO Server/BSGO Server/Server/Protocols/SubscribeProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/SubscribeProtocol.cs
@@ -4,7 +4,7 @@ namespace BSGO_Server
 {
     internal class SubscribeProtocol : Protocol
     {
-        public enum Reply : byte
+        public enum Reply : ushort
         {
             PlayerName = 1,
             PlayerFaction,
@@ -22,7 +22,7 @@ namespace BSGO_Server
             PlayerTournamentIndicator
         }
 
-        public enum Request : byte
+        public enum Request : ushort
         {
             Info = 1,
             Subscribe,
@@ -32,11 +32,11 @@ namespace BSGO_Server
         }
 
         public SubscribeProtocol()
-            : base(ProtocolID.Subscribe) { }
+            : base(ProtocolIDType.Subscribe) { }
         
 
         public static SubscribeProtocol GetProtocol() =>
-            ProtocolManager.GetProtocol(ProtocolID.Subscribe) as SubscribeProtocol;
+            ProtocolManager.GetProtocol(ProtocolIDType.Subscribe) as SubscribeProtocol;
         
         public override void ParseMessage(int index, BgoProtocolReader br)
         {

--- a/BSGO Server/BSGO Server/Server/Protocols/SubscribeProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/SubscribeProtocol.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace BSGO_Server
 {
-    class SubscribeProtocol : Protocol
+    internal class SubscribeProtocol : Protocol
     {
-        public enum Reply : ushort
+        public enum Reply : byte
         {
             PlayerName = 1,
             PlayerFaction,
@@ -24,7 +22,7 @@ namespace BSGO_Server
             PlayerTournamentIndicator
         }
 
-        public enum Request : ushort
+        public enum Request : byte
         {
             Info = 1,
             Subscribe,
@@ -34,34 +32,34 @@ namespace BSGO_Server
         }
 
         public SubscribeProtocol()
-            : base(ProtocolID.Subscribe)
-        {
-        }
+            : base(ProtocolID.Subscribe) { }
+        
 
-        public static SubscribeProtocol GetProtocol()
-        {
-            return ProtocolManager.GetProtocol(ProtocolID.Subscribe) as SubscribeProtocol;
-        }
-
+        public static SubscribeProtocol GetProtocol() =>
+            ProtocolManager.GetProtocol(ProtocolID.Subscribe) as SubscribeProtocol;
+        
         public override void ParseMessage(int index, BgoProtocolReader br)
         {
-            ushort msgType = (ushort)br.ReadUInt16();
+            ushort msgType = br.ReadUInt16();
 
             switch ((Request)msgType)
             {
                 case Request.Info:
+                    /* ?
                     uint playerId = br.ReadUInt32();
                     uint flags = br.ReadUInt32();
+                    */
                     break;
                 default:
-                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, protocolID));
+                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", (Request)msgType, ProtocolID));
                     break;
             }
         }
-
+        /* ?
         public void SendInfo(int index)
         {
 
         }
+        */
     }
 }

--- a/BSGO Server/BSGO Server/Server/Protocols/SyncProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/SyncProtocol.cs
@@ -4,21 +4,21 @@ namespace BSGO_Server
 {
     internal class SyncProtocol : Protocol
     {
-        public enum Request : byte
+        public enum Request : ushort
         {
             SyncRequest
         }
 
-        public enum Reply : byte
+        public enum Reply : ushort
         {
             SyncReply = 1
         }
 
         public SyncProtocol()
-            : base(ProtocolID.Sync) { }
+            : base(ProtocolIDType.Sync) { }
 
         public static SyncProtocol GetProtocol() =>
-            ProtocolManager.GetProtocol(ProtocolID.Sync) as SyncProtocol;
+            ProtocolManager.GetProtocol(ProtocolIDType.Sync) as SyncProtocol;
         
         public override void ParseMessage(int index, BgoProtocolReader br)
         {

--- a/BSGO Server/BSGO Server/Server/Protocols/SyncProtocol.cs
+++ b/BSGO Server/BSGO Server/Server/Protocols/SyncProtocol.cs
@@ -1,34 +1,28 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace BSGO_Server
 {
-    class SyncProtocol : Protocol
+    internal class SyncProtocol : Protocol
     {
-        public enum Request : ushort
+        public enum Request : byte
         {
             SyncRequest
         }
 
-        public enum Reply : ushort
+        public enum Reply : byte
         {
             SyncReply = 1
         }
 
         public SyncProtocol()
-            : base(ProtocolID.Sync)
-        {
-        }
+            : base(ProtocolID.Sync) { }
 
-        public static SyncProtocol GetProtocol()
-        {
-            return ProtocolManager.GetProtocol(ProtocolID.Sync) as SyncProtocol;
-        }
-
+        public static SyncProtocol GetProtocol() =>
+            ProtocolManager.GetProtocol(ProtocolID.Sync) as SyncProtocol;
+        
         public override void ParseMessage(int index, BgoProtocolReader br)
         {
-            ushort msgType = (ushort)br.ReadUInt16();
+            ushort msgType = br.ReadUInt16();
 
             switch ((Request)msgType)
             {
@@ -36,7 +30,7 @@ namespace BSGO_Server
                     SendSync(index);
                     break;
                 default:
-                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", msgType, protocolID));
+                    Log.Add(LogSeverity.ERROR, string.Format("Unknown msgType \"{0}\" on {1}Protocol.", msgType, ProtocolID));
                     break;
             }
         }
@@ -45,7 +39,7 @@ namespace BSGO_Server
         // 3 times in a row.
         private void SendSync(int index)
         {
-            BgoProtocolWriter buffer = NewMessage();
+            using BgoProtocolWriter buffer = NewMessage();
             buffer.Write((ushort)1);
             buffer.Write((ulong)DateTime.UtcNow.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds);
             SendMessageToUser(index,buffer);

--- a/BSGO Server/BSGO Server/Server/Server.cs
+++ b/BSGO Server/BSGO Server/Server/Server.cs
@@ -71,12 +71,8 @@ namespace BSGO_Server
         public static void SendDataToClient(int index, BgoProtocolWriter message)
         {
             foreach (Client currentClient in clients)
-            {
                 if (currentClient.Socket != null && !currentClient.Closing && currentClient.Index == index)
-                {
                     currentClient.Socket.Send(message.GetBuffer(), 0, message.GetLength(), SocketFlags.None);
-                }
-            }
         }
 
         /// <summary>
@@ -101,10 +97,9 @@ namespace BSGO_Server
         public static Client GetClientByPlayerId(string id)
         {
             foreach (Client client in clients)
-            {
-                if (client.playerId == uint.Parse(id))
+                if (client.PlayerId == uint.Parse(id))
                     return client;
-            }
+            
             return null;
         }
     }

--- a/BSGO Server/BSGO Server/Server/Server.cs
+++ b/BSGO Server/BSGO Server/Server/Server.cs
@@ -48,14 +48,14 @@ namespace BSGO_Server
 
             for (int i = 1; i < MaxPlayers; i++)
             {
-                if (_clients[i].socket == null)
+                if (_clients[i].Socket == null)
                 {
-                    _clients[i].socket = socket;
-                    _clients[i].index = i;
-                    _clients[i].ip = socket.RemoteEndPoint.ToString();
+                    _clients[i].Socket = socket;
+                    _clients[i].Index = i;
+                    _clients[i].Ip = socket.RemoteEndPoint.ToString();
                     _clients[i].StartClient();
 
-                    Log.Add(LogSeverity.INFO, string.Format("Connection from '{0}' received.", _clients[i].ip));
+                    Log.Add(LogSeverity.INFO, string.Format("Connection from '{0}' received.", _clients[i].Ip));
 
                     // We should send the ConnectionOK method from the LoginProtocol otherwise the game
                     // will be stuck on a "connecting" screen with no errors since it is just waiting for
@@ -75,9 +75,9 @@ namespace BSGO_Server
         {
             foreach (Client clients in _clients)
             {
-                if (clients.socket != null && !clients.closing && clients.index == index)
+                if (clients.Socket != null && !clients.Closing && clients.Index == index)
                 {
-                    clients.socket.Send(message.GetBuffer(), 0, message.GetLength(), SocketFlags.None);
+                    clients.Socket.Send(message.GetBuffer(), 0, message.GetLength(), SocketFlags.None);
                 }
             }
         }
@@ -89,9 +89,9 @@ namespace BSGO_Server
         /// <returns></returns>
         public static Client GetClientByIndex(int index)
         {
-            foreach(Client client in _clients)
+            foreach (Client client in _clients)
             {
-                if (client.index == index)
+                if (client.Index == index)
                     return client;
             }
             return null;


### PR DESCRIPTION
Just a PR to clean up some code/add semi-required stuff, and to comply with C# standards/code quality. The changes were:

- [Using auto-properties rather than public fields](https://stackoverflow.com/questions/295104/what-is-the-difference-between-a-field-and-a-property)
- Changing a few null comparisons to `is` rather than `==` due to operator overloading
- Complying with naming conventions for public properties (aka first letter must be capitalized)
- Removing useless `using` directives to clean up current namespace, and to prevent name collisions
- Property get accessors/methods use the `=>` bodied-expression operator if possible to clean up  accessors/methods with one statement
- A few switch **statements** (`switch(thing) {code}`) in get accessors have been changed to use the bodied-expression operator, and with the switch **expression** (`property => thing switch {code}`) rather than the switch **statement** 
- Unnecessary casts removed 
- Classes/structs/enums with no access modifier (implicitly `internal`) are now explicitly `internal`
- Empty if statements were commented out for now
- Changing private fields to `readonly` if appropriate
- Replacing `list.Add(?)` calls with `List<T>` object initializers for cleanup (aka instead of a bunch of `list.Add(?)` calls, everything is initialized if possible, such as `new List<T> {item1, item2}`
- All properties which originally pointed to private fields (the old way) are now auto-properties
- Classes which only had static members are now static themselves
- `BgoProtocolWriter` implements `IDisposable` and `IAsyncDisposable` to ensure itself and its containing `MemoryStream` gets released and cleaned up properly

~~Also, proposal: add an open source license, such as MIT for the reason (quoted from [here](https://choosealicense.com/no-permission/))~~
> ~~When you make a creative work (which includes code), the work is under exclusive copyright by default. Unless you include a license that specifies otherwise, nobody else can copy, distribute, or modify your work without being at risk of take-downs, shake-downs, or litigation. Once the work has other contributors (each a copyright holder), “nobody” starts including you.~~

GNU-AGPL 3.0 has been added

~~Not in this PR, but good to consider:~~
- ~~Minor: some of the floating-point data type comparisons might be a tenth off in terms of precision due to casting and operator overloads which don't take into account for these comparisons~~ 
Quick rounding/whole number type casting fixed that, ignore

~~Removed:~~
- ~~Enum integral types have been changed to `byte` rather than types such as `ushort` or `uint` if possible, to reduce bytes used~~
Turns out server won't allow this 